### PR TITLE
Share build output cache across atomize, verify, and pipeline

### DIFF
--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -88,13 +88,14 @@ def runAtomizeInProject (config : AtomizeConfig) : IO UInt32 := do
     IO.eprintln s!"Error: Not a Lake project (missing lakefile.lean or lakefile.toml): {config.projectPath}"
     return 1
 
-  -- Build the project first
+  -- Build the project first (and cache output for later verify)
   IO.println s!"Building project at {config.projectPath}..."
   match ← buildProject config.projectPath with
   | .error msg =>
     IO.eprintln msg
     return 1
-  | .ok () => pure ()
+  | .ok buildOutput =>
+    saveCache config.projectPath buildOutput
 
   IO.println "Getting project modules..."
   -- Get the list of project modules

--- a/ProbeLean/Environment.lean
+++ b/ProbeLean/Environment.lean
@@ -27,12 +27,57 @@ def runCmd (cmd : String) (args : Array String) (cwd : Option System.FilePath :=
   let exitCode ← proc.wait
   return (stdout, stderr, exitCode)
 
-/-- Build the target project using lake -/
-def buildProject (projectPath : System.FilePath) : IO (Except String Unit) := do
-  let (_, stderr, exitCode) ← runCmd "lake" #["build"] projectPath
+/-- Build the target project using lake, returning combined stdout+stderr on success -/
+def buildProject (projectPath : System.FilePath) : IO (Except String String) := do
+  let (stdout, stderr, exitCode) ← runCmd "lake" #["build"] projectPath
   if exitCode != 0 then
     return .error s!"Lake build failed:\n{stderr}"
-  return .ok ()
+  return .ok (stdout ++ "\n" ++ stderr)
+
+/-- Get cache directory path -/
+def getCacheDir (projectPath : System.FilePath) : System.FilePath :=
+  projectPath / ".lake" / "probe-lean"
+
+/-- Get cache file paths -/
+def getCacheFiles (projectPath : System.FilePath) : System.FilePath × System.FilePath :=
+  let cacheDir := getCacheDir projectPath
+  (cacheDir / "build_output.txt", cacheDir / "build_config.json")
+
+/-- Recursively check if any .lean file is newer than cache -/
+partial def checkFilesNewerThan (dir : System.FilePath) (cacheTime : IO.FS.SystemTime) : IO Bool := do
+  let entries ← dir.readDir
+  for entry in entries do
+    let path := entry.path
+    if ← path.isDir then
+      if ← checkFilesNewerThan path cacheTime then return true
+    else if path.extension == some "lean" then
+      let fileMeta ← path.metadata
+      if fileMeta.modified > cacheTime then return true
+  return false
+
+/-- Check if cache is valid (exists and newer than any .lean file) -/
+def isCacheValid (projectPath : System.FilePath) : IO Bool := do
+  let (outputCache, _) := getCacheFiles projectPath
+  if !(← outputCache.pathExists) then return false
+  let cacheMeta ← outputCache.metadata
+  let cacheTime := cacheMeta.modified
+  let hasNewerFile ← checkFilesNewerThan projectPath cacheTime
+  return !hasNewerFile
+
+/-- Save build output to cache -/
+def saveCache (projectPath : System.FilePath) (output : String) : IO Unit := do
+  let cacheDir := getCacheDir projectPath
+  IO.FS.createDirAll cacheDir
+  let (outputCache, _) := getCacheFiles projectPath
+  IO.FS.writeFile outputCache output
+
+/-- Load build output from cache -/
+def loadCache (projectPath : System.FilePath) : IO (Option String) := do
+  let (outputCache, _) := getCacheFiles projectPath
+  if ← outputCache.pathExists then
+    some <$> IO.FS.readFile outputCache
+  else
+    return none
 
 /-- Recursively collect .olean files and convert to module names -/
 partial def collectOleanFiles (basePath : System.FilePath) (currentPath : System.FilePath) : IO (Array Lean.Name) := do

--- a/ProbeLean/Pipeline.lean
+++ b/ProbeLean/Pipeline.lean
@@ -58,6 +58,7 @@ def runPipelineInProject (config : PipelineConfig) : IO UInt32 := do
     IO.eprintln s!"Lake build failed:\n{buildStderr}"
     return 1
   let buildOutput := buildStdout ++ "\n" ++ buildStderr
+  saveCache config.projectPath buildOutput
 
   -- === Step 1: Atomize ===
   IO.println "=== Step 1/3: Atomize ==="

--- a/ProbeLean/Verify.lean
+++ b/ProbeLean/Verify.lean
@@ -129,58 +129,9 @@ def atomToProofEntry (atom : Atom) (sorries : Array SorryInfo) : ProofEntry :=
     sorries := sorries
   }
 
-/-- Run lake build and capture output -/
+/-- Run lake build and capture output (verify ignores exit code to still parse sorries) -/
 def runLakeBuild (projectPath : System.FilePath) : IO (String × String × UInt32) := do
   runCmd "lake" #["build"] (some projectPath)
-
-/-- Get cache directory path -/
-def getCacheDir (projectPath : System.FilePath) : System.FilePath :=
-  projectPath / ".lake" / "probe-lean"
-
-/-- Get cache file paths -/
-def getCacheFiles (projectPath : System.FilePath) : System.FilePath × System.FilePath :=
-  let cacheDir := getCacheDir projectPath
-  (cacheDir / "build_output.txt", cacheDir / "build_config.json")
-
-/-- Recursively check if any .lean file is newer than cache -/
-partial def checkFilesNewerThan (dir : System.FilePath) (cacheTime : IO.FS.SystemTime) : IO Bool := do
-  let entries ← dir.readDir
-  for entry in entries do
-    let path := entry.path
-    if ← path.isDir then
-      if ← checkFilesNewerThan path cacheTime then return true
-    else if path.extension == some "lean" then
-      let fileMeta ← path.metadata
-      if fileMeta.modified > cacheTime then return true
-  return false
-
-/-- Check if cache is valid (exists and newer than any .lean file) -/
-def isCacheValid (projectPath : System.FilePath) : IO Bool := do
-  let (outputCache, _) := getCacheFiles projectPath
-  if !(← outputCache.pathExists) then return false
-
-  -- Get cache modification time
-  let cacheMeta ← outputCache.metadata
-  let cacheTime := cacheMeta.modified
-
-  -- Check if any .lean file is newer
-  let hasNewerFile ← checkFilesNewerThan projectPath cacheTime
-  return !hasNewerFile
-
-/-- Save build output to cache -/
-def saveCache (projectPath : System.FilePath) (output : String) : IO Unit := do
-  let cacheDir := getCacheDir projectPath
-  IO.FS.createDirAll cacheDir
-  let (outputCache, _) := getCacheFiles projectPath
-  IO.FS.writeFile outputCache output
-
-/-- Load build output from cache -/
-def loadCache (projectPath : System.FilePath) : IO (Option String) := do
-  let (outputCache, _) := getCacheFiles projectPath
-  if ← outputCache.pathExists then
-    some <$> IO.FS.readFile outputCache
-  else
-    return none
 
 /-- Convert atoms to proofs output (as JSON object keyed by name) -/
 def atomsToProofsJson (atoms : AtomsOutput) (warnings : Array SorryWarning) : Json :=


### PR DESCRIPTION
## Summary

- **Eliminates redundant `lake build`** when running `atomize` then `verify` sequentially. Previously `atomize` discarded build stdout and `verify` always had to rebuild (or rely on its own cache from a prior `verify` run).
- **Moves cache functions** (`getCacheDir`, `getCacheFiles`, `isCacheValid`, `saveCache`, `loadCache`, `checkFilesNewerThan`) from `Verify.lean` to `Environment.lean` so all commands share the same cache at `.lake/probe-lean/build_output.txt`.
- **`buildProject` now returns combined stdout+stderr** on success (was `Except String Unit`, now `Except String String`), enabling callers to cache the output.
- **`atomize` and `pipeline` now populate the cache** after building, so a subsequent `verify` hits the cache instead of rebuilding.

All JSON outputs are identical to before — the only new side effect is the cache file written by `atomize` and `pipeline`.

## Test plan

- [x] `lake build` succeeds
- [x] All 86 tests pass (`lake build tests && .lake/build/bin/tests`)
- [ ] Manual: run `probe-lean atomize <project>`, then `probe-lean verify <project>` — verify should print "Using cached build output..." instead of "Building project..."

Made with [Cursor](https://cursor.com)