### PR TITLE
fix: detect instance kind in getDeclKind

### DIFF
--- a/ProbeLean/Analysis.lean
+++ b/ProbeLean/Analysis.lean
@@ -60,12 +60,23 @@ def isProjectDecl (env : Environment) (projectModules : Array Name) (name : Name
     -- This shouldn't happen for our use case where we import modules
     false
 
+/-- Check if a declaration is an auto-named type class instance.
+    Lean auto-names instances with an `inst` prefix (e.g., `instAddNat`,
+    `instDecidableValidLengths`). User-named instances are not detected
+    by this heuristic. -/
+def isInstanceName (name : Name) : Bool :=
+  match name.componentsRev.head? with
+  | some (.str _ s) => s.startsWith "inst"
+  | _ => false
+
 /-- Determine the kind of a declaration -/
 def getDeclKind (env : Environment) (name : Name) (info : ConstantInfo) : DeclKind :=
   match info with
   | .defnInfo defInfo =>
-    -- Check if it's an abbreviation (reducible)
-    if defInfo.hints.isAbbrev then
+    -- Check instance first (before abbrev, since instances can be either)
+    if isInstanceName name then
+      .instance
+    else if defInfo.hints.isAbbrev then
       .abbrev
     else
       .def


### PR DESCRIPTION
## Summary

- Add `isInstanceName` helper that checks if a declaration's last name component starts with `inst` — Lean's auto-naming convention for type class instances (e.g., `instAddNat`, `instDecidableValidLengths`)
- Use it in the `defnInfo` branch of `getDeclKind` before the `isAbbrev` check, since instances can be either abbreviations or regular defs
- Previously, all instances were classified as `def` or `abbrev` because Lean stores them as `defnInfo` and the instance extension state is not preserved in `.olean` files after `importModules`

### Why naming heuristic?

Lean's `Meta.instanceExtension.getState env` and `Meta.isInstance` both return empty results after `importModules` — the instance registration metadata is not persisted in `.olean` files. The naming heuristic catches auto-named instances; user-named instances (without `inst` prefix) are not detected.

### Validation on lean-zip

Ran the fix on [lean-zip](https://github.com/kim-em/lean-zip). Found **10 instance atoms** (previously classified as `def`):

| Atom | Source |
|---|---|
| `instDecidableValidLengths` | Explicit `instance : Decidable (ValidLengths ...)` |
| `instReprEntry` (×2) | `deriving Repr` on Archive.Entry and Tar.Entry |
| `instInhabitedEntry` (×2) | `deriving Inhabited` on Archive.Entry and Tar.Entry |
| `instBEqLZ77Symbol` | `deriving BEq` on LZ77Symbol |
| `instReprLZ77Symbol` | `deriving Repr` on LZ77Symbol |
| `instReprBuildTree` | `deriving Repr` on BuildTree |
| `instBEqLZ77Token` | `deriving BEq` on LZ77Token |
| `instInhabitedLZ77Token` | `deriving Inhabited` on LZ77Token |

Note: 2 `Nonempty` instances (`instNonemptyDeflateState`, `instNonemptyInflateState`) remain as `theorem` because Lean stores propositional instances as `thmInfo` — this is correct.

---
Closes #17 