### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.7] - 2026-04-10
+
+### Fixed
+
+- **Instance kind detection**: Auto-named type class instances (e.g.,
+  `instAddNat`, `instDecidableValidLengths`) were incorrectly classified as
+  `"def"` or `"abbrev"`. They are now reported as `"instance"` in the JSON
+  output. Detection uses a naming heuristic (`inst` prefix) since Lean's
+  instance extension state is not preserved in `.olean` files after
+  `importModules`. User-named instances (without `inst` prefix) are not
+  detected. Fixes [#17](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/17).
+
 ## [0.4.6] - 2026-04-09
 
 ### Fixed

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.4.6"
+def version : String := "0.4.7"
 
 end ProbeLean

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.4.6"
+version = "0.4.7"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
## Summary

Version bump for the instance kind detection fix (#17, merged in #20).

### Changed files
- `lakefile.toml`: version `0.4.6` → `0.4.7`
- `ProbeLean/Version.lean`: version `0.4.6` → `0.4.7`
- `CHANGELOG.md`: added `[0.4.7]` entry

### Changelog entry

> **Instance kind detection**: Auto-named type class instances (e.g., `instAddNat`, `instDecidableValidLengths`) were incorrectly classified as `"def"` or `"abbrev"`. They are now reported as `"instance"` in the JSON output. Detection uses a naming heuristic (`inst` prefix) since Lean's instance extension state is not preserved in `.olean` files after `importModules`. User-named instances (without `inst` prefix) are not detected. Fixes #17.