### PR TITLE
docs: describe primary-spec detection in How It Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 2. **Atomize** -- walks the Lean environment, extracts declarations with type and term dependencies
 3. **Filter** -- applies config-based flags (`is-hidden`, `is-extraction-artifact`, `is-ignored`, `is-relevant`)
 4. **Verify** -- parses sorry warnings from build output to determine verification status; axioms, `*External.lean` declarations, and auto-generated declarations without source location are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"external"`, or `"auto-generated"`) for trust-base classification (skippable via `--skip-verify`)
-5. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom
+5. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom. 
+    - To identify the primary specification for a definition, tag the theorem with `@[primary_spec]` (requires `import ProbeLean.Attrs` in the target project). 
+    - If no `@[primary_spec]` attribute is found, probe-lean falls back to a naming heuristic: a theorem named `<def>_spec` is automatically assigned as the primary spec.
+    - Only one primary spec per definition. If multiple `@[primary_spec]` theorems reference the same definition, the last one encountered is used.
 6. **Schema 2.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
 
 ## Testing


### PR DESCRIPTION
## Summary

Expand step 5 (Specs) in the "How It Works" section to explain how users can help probe-lean identify the primary specification for a definition:

1. **`@[primary_spec]` attribute** (preferred) — tag the theorem directly (requires `import ProbeLean.Attrs` in the target project)
2. **`_spec` suffix heuristic** (fallback) — name the theorem `<def>_spec` and it's automatically assigned
