### PR TITLE
fix(extract): require .olean presence for cache validity (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale build cache hit after `lake clean`** ([#15](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/15)):
+  `isCacheValid` now requires at least one `.olean` file in the project's build
+  directory, not just that the directory exists. Previously, after `lake clean`
+  removed `.olean` artifacts (while the cache file at `.lake/probe-lean/build_output.txt`
+  and the `.lake/build/lib/` directory survived), `probe-lean extract` would skip
+  `lake build` and then fail with "No modules found in project". Added a
+  `hasAnyOlean` helper that short-circuits on the first `.olean` found.
+
 ## [0.6.2] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-30
+
 ### Fixed
 
 - **Stale build cache hit after `lake clean`** ([#15](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/15)):

--- a/ProbeLean/Environment.lean
+++ b/ProbeLean/Environment.lean
@@ -75,15 +75,35 @@ partial def checkFilesNewerThan (dir : System.FilePath) (cacheTime : IO.FS.Syste
       if fileMeta.modified > cacheTime then return true
   return false
 
-/-- Check if cache is valid: cache file exists, build output directory exists,
-    config files (lean-toolchain, lakefile) haven't changed, and no .lean source
-    is newer than the cache. -/
+/-- Recursively check whether `dir` contains at least one `.olean` file.
+    Short-circuits on the first hit. Used by `isCacheValid` to detect
+    `lake clean` having removed build artifacts while leaving the directory
+    tree (or cache file) in place. -/
+partial def hasAnyOlean (dir : System.FilePath) : IO Bool := do
+  let entries ← dir.readDir
+  for entry in entries do
+    let path := entry.path
+    if ← path.isDir then
+      if ← hasAnyOlean path then return true
+    else if path.extension == some "olean" then
+      return true
+  return false
+
+/-- Check if cache is valid: cache file exists, build output directory contains
+    at least one `.olean`, config files (lean-toolchain, lakefile) haven't changed,
+    and no .lean source is newer than the cache. -/
 def isCacheValid (projectPath : System.FilePath) : IO Bool := do
   let (outputCache, _) := getCacheFiles projectPath
   if !(← outputCache.pathExists) then return false
   let buildLibLean := projectPath / ".lake" / "build" / "lib" / "lean"
   let buildLib := projectPath / ".lake" / "build" / "lib"
-  if !(← buildLibLean.pathExists) && !(← buildLib.pathExists) then return false
+  let buildDir ←
+    if ← buildLibLean.pathExists then pure (some buildLibLean)
+    else if ← buildLib.pathExists then pure (some buildLib)
+    else pure none
+  match buildDir with
+  | none => return false
+  | some d => unless ← hasAnyOlean d do return false
   let cacheMeta ← outputCache.metadata
   let cacheTime := cacheMeta.modified
   let configFiles := #[

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.6.2"
+def version : String := "0.6.3"
 
 end ProbeLean

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -2038,11 +2038,24 @@ def testCacheValidity (result : TestResult) : IO TestResult := do
   let v2 ← isCacheValid tmpBase
   result ← test "cache file but no build dir → invalid" (!v2) result
 
-  -- Create build dir → valid (no .lean files to be newer)
+  -- Create empty build dir (post-`lake clean` scenario) → invalid
   let buildDir := tmpBase / ".lake" / "build" / "lib" / "lean"
   IO.FS.createDirAll buildDir
   let v3 ← isCacheValid tmpBase
-  result ← test "cache file + build dir → valid" v3 result
+  result ← test "empty build dir (post lake clean) → invalid" (!v3) result
+
+  -- Add an .olean → valid
+  IO.FS.writeFile (buildDir / "Foo.olean") ""
+  let v3b ← isCacheValid tmpBase
+  result ← test "cache file + build dir with .olean → valid" v3b result
+
+  -- Remove the .olean (simulating lake clean leaving the dir behind) → invalid
+  IO.FS.removeFile (buildDir / "Foo.olean")
+  let v3c ← isCacheValid tmpBase
+  result ← test "olean removed but dir kept → invalid" (!v3c) result
+
+  -- Restore .olean for the remaining timestamp-based assertions
+  IO.FS.writeFile (buildDir / "Foo.olean") ""
 
   -- Touch lean-toolchain after cache → invalid
   IO.sleep 1100

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.6.2"
+version = "0.6.3"
 defaultTargets = ["probe-lean"]
 
 [[require]]

--- a/specs/active/stale-cache-detection.md
+++ b/specs/active/stale-cache-detection.md
@@ -6,7 +6,7 @@ When `.olean` files are missing or stale (e.g., after `lake clean` or a toolchai
 
 ## Requirements
 
-- [ ] `isCacheValid` must verify that the project's `.olean` build directory exists, not just that the cache file is newer than `.lean` sources
+- [x] `isCacheValid` must verify that the project's `.olean` build directory exists, not just that the cache file is newer than `.lean` sources
 - [ ] When `incompatible header` occurs but the toolchain versions match, suggest `lake clean` instead of "update probe-lean's lean-toolchain"
 - [ ] The bash install script's cleanup bug (local variables in EXIT trap) must be fixed
 


### PR DESCRIPTION
## Summary

Closes #15. `isCacheValid` previously deemed the cache valid as long as the `.lake/build/lib/` directory existed, regardless of its contents. After `lake clean`, the directory typically survives empty (alongside `.lake/probe-lean/build_output.txt`, which `lake clean` does not touch), so `probe-lean extract` would skip `lake build` and then fail with "No modules found in project".

- Added `hasAnyOlean` (short-circuits on the first `.olean` it finds) and made `isCacheValid` require at least one `.olean` in the build directory.
- Flipped the existing test that asserted the buggy behavior; added two new cases (`olean present → valid`, `olean removed but dir kept → invalid`) as a regression guard for #15.
- Ticked the corresponding checkbox in `specs/active/stale-cache-detection.md` (the other two items in that spec — incompatible-header hint, bash install EXIT trap — remain follow-ups).

## Verification

Reproduced the bug end-to-end on three target projects, then re-ran with the fixed binary:

| Project | Pre-fix | Fixed |
|---|---|---|
| `curve25519-dalek-lean-verify` (v4.28.0-rc1) | `Build cache is up-to-date, skipping...` → `Error: No modules found` | `Building project at ...` → 1593 atoms extracted |
