### PR TITLE
ci(release): add Lean v4.29.0 to pre-built binary matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           - v4.28.0
           - v4.29.0-rc4
           - v4.29.0-rc8
+          - v4.29.0
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
## Summary

Adds Lean **v4.29.0** (final) to `release.yml`'s build matrix so users on that toolchain (e.g. cedar-spec) can install via the fast tarball path instead of falling back to a local source build via `install.sh`.

This is purely a CI matrix change — one line added. No code or test changes.

## Why

`tools/bash/install.sh` searches probe-lean's release assets for a binary matching the user's Lean version. If the asset doesn't exist, it falls back to compiling from source (works, but takes minutes and needs `elan` + build deps). cedar-spec pins to `leanprover/lean4:v4.29.0` so previously had no fast install path.

## Local verification (mirrors what `release.yml` does)

Built probe-lean v0.6.3 with `lean-toolchain` and `lakefile.toml`'s Cli rev rewritten to `v4.29.0` (the same rewrite the CI matrix step performs at lines 37-40 of release.yml), then ran the same three-layer check we did for the v4.29.0-rc4 build on lean-zip:

| Layer | Result |
|---|---|
| Unit tests | 346/346 pass against v4.29.0 |
| Cache-check fix (#15) regression on cedar-spec | Correctly invalidates after fake `lake clean` (empty `.lake/build/lib/lean/` + cache file → triggers rebuild) |
| End-to-end probe-lean extract on cedar-spec | 268 modules → 4101 atoms, 4101/4101 verified, 10MB JSON output |