### PR TITLE
ci(auto-tag): use PAT to push release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Read version and create tag if missing
         run: |


### PR DESCRIPTION
## Summary

Switches the `auto-tag` job's `actions/checkout` to use a `RELEASE_PAT` secret instead of the implicit `GITHUB_TOKEN`. This is a one-line change that fixes the broken auto-publish chain.

## Why

After [PR #29](https://github.com/Beneficial-AI-Foundation/probe-lean/pull/29) merged to `main`, the `auto-tag` job correctly created and pushed the `v0.6.3` tag — but `release.yml` (which is triggered by `push: tags: ["v*"]`) never fired. As a result, the v0.6.3 GitHub Release had to be published via manual `workflow_dispatch`.

The cause is documented anti-loop protection in GitHub Actions: events caused by the default `GITHUB_TOKEN` don't trigger other workflows, [per the GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> "An action in a workflow run can't trigger a new workflow run."

The block is on the **token** that produced the event, not on what the operation is — so even using `gh release create` with `GITHUB_TOKEN` wouldn't help. A PAT push is treated as a regular ("human") push and does trigger downstream workflows normally.

## What changes

```diff
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
```

`actions/checkout` persists the credential into the local git config (default behavior), so the subsequent `git push origin "$TAG"` automatically uses the PAT.