### PR TITLE
feat: add transitively-verified status via reverse-BFS enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-22
+
+### Added
+
+- **`transitively-verified` status**: Verified atoms whose transitive dependencies
+  are all verified or trusted are now upgraded to `"transitively-verified"` via
+  reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`). Atoms that
+  are locally sorry-free but have at least one unverified or failed transitive
+  dependency remain `"verified"`.
+- **`--skip-enrich` flag**: Skip the transitive verification enrichment step.
+  When passed, no atoms will be upgraded to `"transitively-verified"`.
+- **`ProbeLean/Transitive.lean`**: New module implementing the enrichment algorithm
+  using `Lean.RBMap` for deterministic iteration and an `Array`-backed BFS queue.
+
 ## [0.6.3] - 2026-04-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Do **not** hardcode version strings anywhere else — use `ProbeLean.version` (o
 
 ### Extract pipeline
 
-`probe-lean extract` runs: **build → atomize → sorry detection → merge → enrich → envelope → write**
+`probe-lean extract` runs: **build → atomize → specs → sorry detection → merge → enrich → envelope → write**
 
 - `ProbeLean/Analysis.lean` — Core analysis: walks Lean environment, extracts dependencies (type vs term)
 - `ProbeLean/Atomize.lean` — Converts declarations to `Atom` structs, applies filtering flags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Do **not** hardcode version strings anywhere else — use `ProbeLean.version` (o
 
 ### Extract pipeline
 
-`probe-lean extract` runs: **build → atomize → sorry detection → merge → envelope → write**
+`probe-lean extract` runs: **build → atomize → sorry detection → merge → enrich → envelope → write**
 
 - `ProbeLean/Analysis.lean` — Core analysis: walks Lean environment, extracts dependencies (type vs term)
 - `ProbeLean/Atomize.lean` — Converts declarations to `Atom` structs, applies filtering flags
@@ -93,6 +93,7 @@ Do **not** hardcode version strings anywhere else — use `ProbeLean.version` (o
 - `ProbeLean/Environment.lean` — Lake project detection, subprocess commands (`runCmd`, `runLakeCmd`), build cache
 - `ProbeLean/VerifyInternal.lean` — Parses sorry warnings from build output
 - `ProbeLean/Extract.lean` — Orchestrates the pipeline, produces `UnifiedAtom` output
+- `ProbeLean/Transitive.lean` — Reverse-BFS contamination for `transitively-verified` status enrichment
 - `ProbeLean/Version.lean` — Single version constant, generated from `lakefile.toml`
 - `ProbeLean/Types.lean` — All data structures and JSON serialization
 - `ProbeLean/View.lean` — `viewify` command (filters atoms → molecules for web UI)

--- a/ProbeLean.lean
+++ b/ProbeLean.lean
@@ -6,5 +6,6 @@ import ProbeLean.Loader
 import ProbeLean.Metadata
 import ProbeLean.Atomize
 import ProbeLean.VerifyInternal
+import ProbeLean.Transitive
 import ProbeLean.Extract
 import ProbeLean.View

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -9,6 +9,7 @@ import ProbeLean.Environment
 import ProbeLean.Metadata
 import ProbeLean.Atomize
 import ProbeLean.VerifyInternal
+import ProbeLean.Transitive
 
 namespace ProbeLean
 
@@ -22,6 +23,7 @@ structure ExtractConfig where
   skipVerify : Bool
   fromFile : Option System.FilePath
   libraries : Option (Array String) := none
+  skipEnrich : Bool := false
   deriving Repr
 
 /-- Map probe-lean VerifyStatus to the web frontend's verification status -/
@@ -111,7 +113,7 @@ def ensureMathlibCache (projectPath : System.FilePath)
     IO.println "  ✓ Mathlib cache downloaded"
     IO.println ""
 
-/-- Run the combined extract pipeline: build → atomize → markAtomFlags → sorry detection → merge → envelope → write -/
+/-- Run the combined extract pipeline: build → atomize → markAtomFlags → sorry detection → merge → enrich → envelope → write -/
 def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   if !(← isLakeProject config.projectPath) then
     IO.eprintln s!"Error: Not a Lake project: {config.projectPath}"
@@ -237,6 +239,17 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   let unifiedAtoms := atoms.mapIdx fun i atom =>
     let proof := proofEntries.bind fun ps => ps[i]?
     unifyAtom atom proof
+
+  -- === Enrich: transitive verification via reverse-BFS ===
+  let unifiedAtoms ← if config.skipEnrich then
+    IO.println "Enrichment skipped (--skip-enrich)"
+    pure unifiedAtoms
+  else do
+    IO.println "=== Enrich ==="
+    let (enriched, transitive, local_) := enrichTransitiveVerification unifiedAtoms
+    let notVerified := enriched.size - transitive - local_
+    IO.println s!"Transitively verified: {transitive} | Locally verified: {local_} | Not verified: {notVerified}"
+    pure enriched
 
   let source ← collectSourceInfo config.projectPath
   let timestamp ← getCurrentTimestamp

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -113,7 +113,7 @@ def ensureMathlibCache (projectPath : System.FilePath)
     IO.println "  ✓ Mathlib cache downloaded"
     IO.println ""
 
-/-- Run the combined extract pipeline: build → atomize → markAtomFlags → sorry detection → merge → enrich → envelope → write -/
+/-- Run the combined extract pipeline: build → atomize → markAtomFlags → specs → sorry detection → merge → enrich → envelope → write -/
 def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   if !(← isLakeProject config.projectPath) then
     IO.eprintln s!"Error: Not a Lake project: {config.projectPath}"
@@ -246,7 +246,9 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
     pure unifiedAtoms
   else do
     IO.println "=== Enrich ==="
-    let (enriched, transitive, local_) := enrichTransitiveVerification unifiedAtoms
+    let (enriched, transitive, local_, missingDeps) := enrichTransitiveVerification unifiedAtoms
+    for dep in missingDeps do
+      IO.eprintln s!"Warning: dependency \"{dep}\" not found in atom map (treated as trusted)"
     let notVerified := enriched.size - transitive - local_
     IO.println s!"Transitively verified: {transitive} | Locally verified: {local_} | Not verified: {notVerified}"
     pure enriched

--- a/ProbeLean/Main.lean
+++ b/ProbeLean/Main.lean
@@ -30,6 +30,7 @@ def runExtract (parsed : Parsed) : IO UInt32 := do
   let fromFile := parsed.flag? "from-file" |>.map (·.as! String) |>.map System.FilePath.mk
   let libraries := parsed.flag? "library" |>.map fun f =>
     (f.as! String).splitOn "," |>.map (fun s => s.trimAscii.toString) |>.toArray
+  let skipEnrich := parsed.hasFlag "skip-enrich"
 
   let config : ExtractConfig := {
     projectPath := projectPath
@@ -38,6 +39,7 @@ def runExtract (parsed : Parsed) : IO UInt32 := do
     skipVerify := skipVerify
     fromFile := fromFile
     libraries := libraries
+    skipEnrich := skipEnrich
   }
 
   runExtractInProject config
@@ -53,6 +55,7 @@ def extractCmd : Cmd := `[Cli|
     "skip-verify"; "Skip the sorry detection step"
     "from-file" : String; "Use existing build output for sorry detection instead of running lake"
     l, library : String; "Comma-separated list of library names to build (default: auto-detect from lakefile.toml)"
+    "skip-enrich"; "Skip transitive verification enrichment"
 
   ARGS:
     projectPath : String; "Path to the Lean 4 project to analyze"

--- a/ProbeLean/Transitive.lean
+++ b/ProbeLean/Transitive.lean
@@ -1,0 +1,91 @@
+/-
+  Transitive verification enrichment via reverse-BFS contamination.
+  Ports the algorithm from probe's propagate.rs to Lean.
+-/
+import Lean
+import ProbeLean.Types
+
+namespace ProbeLean
+
+open Lean
+
+private def isVerified (status : Option WebVerificationStatus) : Bool :=
+  match status with
+  | some .verified | some .transitivelyVerified => true
+  | _ => false
+
+private def isContaminationSource (status : Option WebVerificationStatus) : Bool :=
+  match status with
+  | some .unverified | some .failed => true
+  | _ => false
+
+/-- Enrich verification status through the dependency graph using
+    reverse-BFS contamination.
+
+    For each verified atom, determines whether it is **transitively verified**
+    (all transitive dependencies are verified or trusted) or only
+    **locally verified** (the atom itself is verified but at least one
+    transitive dependency is not).
+
+    Returns `(enrichedAtoms, transitiveCount, localCount)`. -/
+def enrichTransitiveVerification (atoms : Array UnifiedAtom)
+    : Array UnifiedAtom × Nat × Nat := Id.run do
+  -- 1. Build reverse dependency index and verified set
+  let mut reverseDeps : RBMap String (Array String) compare := .empty
+  let mut verifiedSet : RBTree String compare := .empty
+
+  for atom in atoms do
+    if isVerified atom.verificationStatus then
+      verifiedSet := verifiedSet.insert atom.name
+    for dep in atom.dependencies do
+      let cur := (reverseDeps.find? dep).getD #[]
+      reverseDeps := reverseDeps.insert dep (cur.push atom.name)
+
+  -- 2. Seed contamination
+  let mut contaminated : RBTree String compare := .empty
+  for atom in atoms do
+    if isContaminationSource atom.verificationStatus then
+      contaminated := contaminated.insert atom.name
+
+  -- 3. Find direct contacts and start BFS
+  let mut queue : Array String := #[]
+  let initialSources := contaminated.toArray
+  for source in initialSources do
+    match reverseDeps.find? source with
+    | some callers =>
+      for caller in callers do
+        if verifiedSet.contains caller && !contaminated.contains caller then
+          contaminated := contaminated.insert caller
+          queue := queue.push caller
+    | none => pure ()
+
+  -- 4. Propagate via reverse edges (BFS)
+  let mut front : Nat := 0
+  while h : front < queue.size do
+    let atomName := queue[front]
+    front := front + 1
+    match reverseDeps.find? atomName with
+    | some callers =>
+      for caller in callers do
+        if verifiedSet.contains caller && !contaminated.contains caller then
+          contaminated := contaminated.insert caller
+          queue := queue.push caller
+    | none => pure ()
+
+  -- 5. Upgrade non-contaminated verified atoms to transitively-verified
+  let mut transitiveCount : Nat := 0
+  let mut localCount : Nat := 0
+  let mut result := atoms
+
+  for i in [:atoms.size] do
+    let atom := atoms[i]!
+    if verifiedSet.contains atom.name then
+      if contaminated.contains atom.name then
+        localCount := localCount + 1
+      else
+        transitiveCount := transitiveCount + 1
+        result := result.set! i { atom with verificationStatus := some .transitivelyVerified }
+
+  (result, transitiveCount, localCount)
+
+end ProbeLean

--- a/ProbeLean/Transitive.lean
+++ b/ProbeLean/Transitive.lean
@@ -27,17 +27,26 @@ private def isContaminationSource (status : Option WebVerificationStatus) : Bool
     **locally verified** (the atom itself is verified but at least one
     transitive dependency is not).
 
-    Returns `(enrichedAtoms, transitiveCount, localCount)`. -/
+    Returns `(enrichedAtoms, transitiveCount, localCount, missingDeps)`.
+    `missingDeps` lists dependency names not found in the atom map
+    (treated as trusted, matching `probe`'s `propagate.rs` behavior). -/
 def enrichTransitiveVerification (atoms : Array UnifiedAtom)
-    : Array UnifiedAtom × Nat × Nat := Id.run do
-  -- 1. Build reverse dependency index and verified set
+    : Array UnifiedAtom × Nat × Nat × Array String := Id.run do
+  -- 1. Build reverse dependency index, verified set, and track missing deps
   let mut reverseDeps : RBMap String (Array String) compare := .empty
   let mut verifiedSet : RBTree String compare := .empty
+  let mut atomNames : RBTree String compare := .empty
+  let mut missingDepsSet : RBTree String compare := .empty
+
+  for atom in atoms do
+    atomNames := atomNames.insert atom.name
 
   for atom in atoms do
     if isVerified atom.verificationStatus then
       verifiedSet := verifiedSet.insert atom.name
     for dep in atom.dependencies do
+      if !atomNames.contains dep then
+        missingDepsSet := missingDepsSet.insert dep
       let cur := (reverseDeps.find? dep).getD #[]
       reverseDeps := reverseDeps.insert dep (cur.push atom.name)
 
@@ -86,6 +95,6 @@ def enrichTransitiveVerification (atoms : Array UnifiedAtom)
         transitiveCount := transitiveCount + 1
         result := result.set! i { atom with verificationStatus := some .transitivelyVerified }
 
-  (result, transitiveCount, localCount)
+  (result, transitiveCount, localCount, missingDepsSet.toArray)
 
 end ProbeLean

--- a/ProbeLean/Types.lean
+++ b/ProbeLean/Types.lean
@@ -385,6 +385,7 @@ inductive WebVerificationStatus where
   | failed
   | unverified
   | trusted
+  | transitivelyVerified
   deriving Repr, BEq
 
 instance : Lean.ToJson WebVerificationStatus where
@@ -393,6 +394,7 @@ instance : Lean.ToJson WebVerificationStatus where
     | .failed => "failed"
     | .unverified => "unverified"
     | .trusted => "trusted"
+    | .transitivelyVerified => "transitively-verified"
 
 instance : Lean.FromJson WebVerificationStatus where
   fromJson? json := do
@@ -402,6 +404,7 @@ instance : Lean.FromJson WebVerificationStatus where
     | "failed" => return .failed
     | "unverified" => return .unverified
     | "trusted" => return .trusted
+    | "transitively-verified" => return .transitivelyVerified
     | _ => throw s!"Unknown WebVerificationStatus: {s}"
 
 /-- A unified atom combining all atom fields with verification and specification status -/

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.6.3"
+def version : String := "0.7.0"
 
 end ProbeLean

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 | `-l, --library <LIBS>` | Comma-separated list of library names to build (default: `defaultTargets` from `lakefile.toml`, falling back to all `[[lean_lib]]` entries) |
 | `--skip-verify` | Skip sorry detection (graph structure only) |
 | `--from-file <FILE>` | Use existing build output for sorry detection |
+| `--skip-enrich` | Skip transitive verification enrichment (no `"transitively-verified"` status) |
 
 For the full command reference with examples, see **[docs/USAGE.md](docs/USAGE.md)**. For the complete JSON schema specification, see **[docs/SCHEMA.md](docs/SCHEMA.md)**.
 
@@ -130,7 +131,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 {
   "schema": "probe-lean/extract",
   "schema-version": "2.0",
-  "tool": { "name": "probe-lean", "version": "0.2.0", "command": "extract" },
+  "tool": { "name": "probe-lean", "version": "0.7.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
     "commit": "abc123d",
@@ -169,12 +170,13 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 2. **Atomize** -- walks the Lean environment, extracts declarations with type and term dependencies
 3. **Filter** -- applies config-based flags (`is-hidden`, `is-extraction-artifact`, `is-ignored`, `is-relevant`)
 4. **Verify** -- parses sorry warnings from build output to determine verification status (shallow: checks only the declaration's own body, not its dependencies); axioms, declarations tagged `@[externally_verified]`, and non-theorem `*External.lean` declarations are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"externally_verified"`, or `"external"`) for trust-base classification; theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal verification status; declarations without source location (kernel-synthesized) are filtered from output (skippable via `--skip-verify`)
-5. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom using a multi-signal precedence chain:
+5. **Enrich** -- upgrades `"verified"` atoms to `"transitively-verified"` when all transitive dependencies are verified or trusted, using reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`; skippable via `--skip-enrich`)
+6. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom using a multi-signal precedence chain:
     1. `@[primary_spec]` attribute (always wins; requires `import ProbeLean.Attrs` in the target project)
     2. Known verification-framework attributes (`@[progress]`, `@[pspec]`, `@[step]`) — if exactly one spec theorem carries one of these, it becomes primary spec; ambiguous when multiple match
     3. `_spec` suffix — a theorem named `<def>_spec` is assigned as primary spec
     4. Sole spec — if a definition has exactly one spec theorem, it is used as primary spec
-6. **Schema 2.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
+7. **Schema 2.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -169,13 +169,13 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 1. **Build** -- reads `defaultTargets` from `lakefile.toml` (falling back to all `[[lean_lib]]` entries) and runs `lake build <lib1> ...` to produce `.olean` files (automatically skipped when build cache is up-to-date; overridable via `--library`)
 2. **Atomize** -- walks the Lean environment, extracts declarations with type and term dependencies
 3. **Filter** -- applies config-based flags (`is-hidden`, `is-extraction-artifact`, `is-ignored`, `is-relevant`)
-4. **Verify** -- parses sorry warnings from build output to determine verification status (shallow: checks only the declaration's own body, not its dependencies); axioms, declarations tagged `@[externally_verified]`, and non-theorem `*External.lean` declarations are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"externally_verified"`, or `"external"`) for trust-base classification; theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal verification status; declarations without source location (kernel-synthesized) are filtered from output (skippable via `--skip-verify`)
-5. **Enrich** -- upgrades `"verified"` atoms to `"transitively-verified"` when all transitive dependencies are verified or trusted, using reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`; skippable via `--skip-enrich`)
-6. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom using a multi-signal precedence chain:
+4. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom using a multi-signal precedence chain:
     1. `@[primary_spec]` attribute (always wins; requires `import ProbeLean.Attrs` in the target project)
     2. Known verification-framework attributes (`@[progress]`, `@[pspec]`, `@[step]`) — if exactly one spec theorem carries one of these, it becomes primary spec; ambiguous when multiple match
     3. `_spec` suffix — a theorem named `<def>_spec` is assigned as primary spec
     4. Sole spec — if a definition has exactly one spec theorem, it is used as primary spec
+5. **Verify** -- parses sorry warnings from build output to determine verification status (shallow: checks only the declaration's own body, not its dependencies); axioms, declarations tagged `@[externally_verified]`, and non-theorem `*External.lean` declarations are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"externally_verified"`, or `"external"`) for trust-base classification; theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal verification status; declarations without source location (kernel-synthesized) are filtered from output (skippable via `--skip-verify`)
+6. **Enrich** -- upgrades `"verified"` atoms to `"transitively-verified"` when all transitive dependencies are verified or trusted, using reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`; skippable via `--skip-enrich`)
 7. **Schema 2.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
 
 ## Testing

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -1606,7 +1606,7 @@ def testExampleJsonVerificationStatus (result : TestResult) : IO TestResult := d
     match data.getObj? with
     | .error _ => return result.add false
     | .ok obj => do
-      let validStatuses := ["verified", "unverified", "failed", "trusted"]
+      let validStatuses := ["verified", "unverified", "failed", "trusted", "transitively-verified"]
       let validReasons := ["axiom", "external", "externally_verified"]
       let mut allValid := true
       let mut hasVerified := false
@@ -1976,7 +1976,7 @@ def testLeanInvariants (result : TestResult) : IO TestResult := do
   result ← test "sorries maps to unverified" (vs2 == .unverified) result
   result ← test "failure maps to failed" (vs3 == .failed) result
 
-  let validStatuses := #["verified", "unverified", "failed", "trusted"]
+  let validStatuses := #["verified", "unverified", "failed", "trusted", "transitively-verified"]
   let vsJson1 := Lean.toJson vs1
   let vsJson2 := Lean.toJson vs2
   let vsJson3 := Lean.toJson vs3
@@ -2148,6 +2148,227 @@ def testNixEnv (result : TestResult) : IO TestResult := do
   try IO.FS.removeDirAll tmpBase catch _ => pure ()
   return result
 
+private def mkUnified (name : String) (deps : Array String)
+    (status : Option WebVerificationStatus := none) : UnifiedAtom :=
+  { name, displayName := name, dependencies := deps,
+    codeModule := "Test", codePath := "Test.lean",
+    codeText := some { linesStart := 1, linesEnd := 5 },
+    kind := .def, verificationStatus := status }
+
+private def getVS (atom : UnifiedAtom) : Option WebVerificationStatus :=
+  atom.verificationStatus
+
+private def findUA (atoms : Array UnifiedAtom) (name : String) : Option UnifiedAtom :=
+  atoms.find? fun a => a.name == name
+
+def testTransitiveVerificationBasic (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing enrichTransitiveVerification basic cases..."
+
+  -- Leaf verified atom -> transitively-verified
+  let a := mkUnified "a" #[] (some .verified)
+  let (res, t, l) := enrichTransitiveVerification #[a]
+  result ← test "leaf verified -> transitively-verified"
+    (getVS (findUA res "a").get! == some .transitivelyVerified) result
+  result ← test "leaf counts: transitive=1, local=0" (t == 1 && l == 0) result
+
+  -- All deps verified -> all transitively-verified
+  let a2 := mkUnified "a" #["b"] (some .verified)
+  let b2 := mkUnified "b" #["c"] (some .verified)
+  let c2 := mkUnified "c" #[] (some .verified)
+  let (res2, t2, l2) := enrichTransitiveVerification #[a2, b2, c2]
+  result ← test "all verified chain -> all transitively-verified"
+    (getVS (findUA res2 "a").get! == some .transitivelyVerified &&
+     getVS (findUA res2 "b").get! == some .transitivelyVerified &&
+     getVS (findUA res2 "c").get! == some .transitivelyVerified) result
+  result ← test "all verified counts: transitive=3, local=0" (t2 == 3 && l2 == 0) result
+
+  -- One dep failed -> caller stays verified (locally)
+  let a3 := mkUnified "a" #["b"] (some .verified)
+  let b3 := mkUnified "b" #[] (some .failed)
+  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  result ← test "dep failed -> caller stays verified"
+    (getVS (findUA res3 "a").get! == some .verified) result
+  result ← test "failed dep unchanged"
+    (getVS (findUA res3 "b").get! == some .failed) result
+
+  -- One dep unverified -> caller stays verified (locally)
+  let a4 := mkUnified "a" #["b"] (some .verified)
+  let b4 := mkUnified "b" #[] (some .unverified)
+  let (res4, _, _) := enrichTransitiveVerification #[a4, b4]
+  result ← test "dep unverified -> caller stays verified"
+    (getVS (findUA res4 "a").get! == some .verified) result
+  result ← test "unverified dep unchanged"
+    (getVS (findUA res4 "b").get! == some .unverified) result
+  return result
+
+def testTransitiveVerificationTrust (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing enrichTransitiveVerification trust and missing..."
+
+  -- Trusted dep does not block
+  let a := mkUnified "a" #["b"] (some .verified)
+  let b := mkUnified "b" #[] (some .trusted)
+  let (res, _, _) := enrichTransitiveVerification #[a, b]
+  result ← test "trusted dep -> caller transitively-verified"
+    (getVS (findUA res "a").get! == some .transitivelyVerified) result
+
+  -- Missing dep (not in map) does not block
+  let a2 := mkUnified "a" #["nonexistent"] (some .verified)
+  let (res2, _, _) := enrichTransitiveVerification #[a2]
+  result ← test "missing dep -> caller transitively-verified"
+    (getVS (findUA res2 "a").get! == some .transitivelyVerified) result
+
+  -- Missing status does not contaminate
+  let a3 := mkUnified "a" #["b"] (some .verified)
+  let b3 := mkUnified "b" #[] none
+  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  result ← test "missing status dep -> caller transitively-verified"
+    (getVS (findUA res3 "a").get! == some .transitivelyVerified) result
+
+  -- Non-verified atoms untouched
+  let a4 := mkUnified "a" #[] (some .unverified)
+  let b4 := mkUnified "b" #[] (some .failed)
+  let c4 := mkUnified "c" #[] none
+  let (res4, _, _) := enrichTransitiveVerification #[a4, b4, c4]
+  result ← test "unverified atom untouched"
+    (getVS (findUA res4 "a").get! == some .unverified) result
+  result ← test "failed atom untouched"
+    (getVS (findUA res4 "b").get! == some .failed) result
+  result ← test "none-status atom untouched"
+    (getVS (findUA res4 "c").get! == none) result
+  return result
+
+def testTransitiveVerificationGraph (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing enrichTransitiveVerification graph patterns..."
+
+  -- Transitive chain: A->B->C, C unverified
+  let a := mkUnified "a" #["b"] (some .verified)
+  let b := mkUnified "b" #["c"] (some .verified)
+  let c := mkUnified "c" #[] (some .unverified)
+  let (res, _, _) := enrichTransitiveVerification #[a, b, c]
+  result ← test "transitive chain: A stays verified"
+    (getVS (findUA res "a").get! == some .verified) result
+  result ← test "transitive chain: B stays verified"
+    (getVS (findUA res "b").get! == some .verified) result
+  result ← test "transitive chain: C stays unverified"
+    (getVS (findUA res "c").get! == some .unverified) result
+
+  -- Diamond dependency with unverified leaf
+  let a2 := mkUnified "a" #["b", "c"] (some .verified)
+  let b2 := mkUnified "b" #["d"] (some .verified)
+  let c2 := mkUnified "c" #["d"] (some .verified)
+  let d2 := mkUnified "d" #[] (some .unverified)
+  let (res2, _, _) := enrichTransitiveVerification #[a2, b2, c2, d2]
+  result ← test "diamond: A stays verified"
+    (getVS (findUA res2 "a").get! == some .verified) result
+  result ← test "diamond: B stays verified"
+    (getVS (findUA res2 "b").get! == some .verified) result
+  result ← test "diamond: C stays verified"
+    (getVS (findUA res2 "c").get! == some .verified) result
+  result ← test "diamond: D stays unverified"
+    (getVS (findUA res2 "d").get! == some .unverified) result
+
+  -- Cycle (all verified) -> transitively-verified
+  let a3 := mkUnified "a" #["b"] (some .verified)
+  let b3 := mkUnified "b" #["a"] (some .verified)
+  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  result ← test "cycle all verified: A transitively-verified"
+    (getVS (findUA res3 "a").get! == some .transitivelyVerified) result
+  result ← test "cycle all verified: B transitively-verified"
+    (getVS (findUA res3 "b").get! == some .transitivelyVerified) result
+
+  -- Cycle with unverified dep
+  let a4 := mkUnified "a" #["b"] (some .verified)
+  let b4 := mkUnified "b" #["c", "d"] (some .verified)
+  let c4 := mkUnified "c" #["a"] (some .verified)
+  let d4 := mkUnified "d" #[] (some .unverified)
+  let (res4, _, _) := enrichTransitiveVerification #[a4, b4, c4, d4]
+  result ← test "cycle with unverified: A stays verified"
+    (getVS (findUA res4 "a").get! == some .verified) result
+  result ← test "cycle with unverified: B stays verified"
+    (getVS (findUA res4 "b").get! == some .verified) result
+  result ← test "cycle with unverified: C stays verified"
+    (getVS (findUA res4 "c").get! == some .verified) result
+  return result
+
+def testTransitiveVerificationProperties (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing enrichTransitiveVerification properties..."
+
+  -- Idempotency
+  let a := mkUnified "a" #["b"] (some .verified)
+  let b := mkUnified "b" #[] (some .unverified)
+  let (res1, _, _) := enrichTransitiveVerification #[a, b]
+  let (res2, _, _) := enrichTransitiveVerification res1
+  result ← test "idempotency: A unchanged after second run"
+    (getVS (findUA res2 "a").get! == getVS (findUA res1 "a").get!) result
+  result ← test "idempotency: B unchanged after second run"
+    (getVS (findUA res2 "b").get! == getVS (findUA res1 "b").get!) result
+
+  -- Idempotency for transitively-verified
+  let c := mkUnified "c" #[] (some .verified)
+  let (res3, _, _) := enrichTransitiveVerification #[c]
+  let (res4, _, _) := enrichTransitiveVerification res3
+  result ← test "idempotency: transitively-verified stays"
+    (getVS (findUA res4 "c").get! == some .transitivelyVerified) result
+
+  -- Counts are correct
+  let a5 := mkUnified "a" #[] (some .verified)
+  let b5 := mkUnified "b" #["c"] (some .verified)
+  let c5 := mkUnified "c" #[] (some .unverified)
+  let (_, t5, l5) := enrichTransitiveVerification #[a5, b5, c5]
+  result ← test "counts: transitive=1, local=1" (t5 == 1 && l5 == 1) result
+
+  -- Explicit unverified contaminates but missing does not
+  let a6 := mkUnified "a" #["b", "c"] (some .verified)
+  let b6 := mkUnified "b" #[] (some .unverified)
+  let c6 := mkUnified "c" #[] none
+  let (res6, _, _) := enrichTransitiveVerification #[a6, b6, c6]
+  result ← test "explicit unverified contaminates, missing does not"
+    (getVS (findUA res6 "a").get! == some .verified) result
+
+  return result
+
+def testTransitiveVerificationJson (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing WebVerificationStatus transitively-verified JSON..."
+  let wvsTransitive := match Lean.FromJson.fromJson?
+      (Lean.toJson WebVerificationStatus.transitivelyVerified)
+      (α := WebVerificationStatus) with
+    | .ok .transitivelyVerified => true | _ => false
+  result ← test "transitivelyVerified round-trips through JSON" wvsTransitive result
+  result ← test "transitivelyVerified toJson"
+    (Lean.toJson WebVerificationStatus.transitivelyVerified == "transitively-verified") result
+
+  IO.println ""
+  IO.println "Testing UnifiedAtom with transitively-verified status..."
+  let tvAtom : UnifiedAtom := {
+    name := "probe:Test.tv"
+    displayName := "tv"
+    dependencies := #[]
+    codeModule := "Test"
+    codePath := "Test.lean"
+    codeText := none
+    kind := .def
+    verificationStatus := some .transitivelyVerified
+  }
+  let tvJson := Lean.toJson tvAtom
+  let tvStatusOk := match tvJson.getObjValAs? String "verification-status" with
+    | .ok "transitively-verified" => true | _ => false
+  result ← test "UnifiedAtom transitively-verified in JSON" tvStatusOk result
+  let tvRtOk := match Lean.FromJson.fromJson? tvJson (α := UnifiedAtom) with
+    | .ok a => a.verificationStatus == some .transitivelyVerified
+    | .error _ => false
+  result ← test "UnifiedAtom transitively-verified round-trips" tvRtOk result
+  return result
+
 def main : IO UInt32 := do
   let mut result : TestResult := { passed := 0, failed := 0 }
   result ← testConstants result
@@ -2188,6 +2409,11 @@ def main : IO UInt32 := do
   result ← testCacheValidity result
   result ← testCheckFilesSkipsDotDirs result
   result ← testNixEnv result
+  result ← testTransitiveVerificationBasic result
+  result ← testTransitiveVerificationTrust result
+  result ← testTransitiveVerificationGraph result
+  result ← testTransitiveVerificationProperties result
+  result ← testTransitiveVerificationJson result
 
   IO.println ""
   IO.println s!"Results: {result.passed} passed, {result.failed} failed"

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -2168,7 +2168,7 @@ def testTransitiveVerificationBasic (result : TestResult) : IO TestResult := do
 
   -- Leaf verified atom -> transitively-verified
   let a := mkUnified "a" #[] (some .verified)
-  let (res, t, l) := enrichTransitiveVerification #[a]
+  let (res, t, l, _) := enrichTransitiveVerification #[a]
   result ← test "leaf verified -> transitively-verified"
     (getVS (findUA res "a").get! == some .transitivelyVerified) result
   result ← test "leaf counts: transitive=1, local=0" (t == 1 && l == 0) result
@@ -2177,7 +2177,7 @@ def testTransitiveVerificationBasic (result : TestResult) : IO TestResult := do
   let a2 := mkUnified "a" #["b"] (some .verified)
   let b2 := mkUnified "b" #["c"] (some .verified)
   let c2 := mkUnified "c" #[] (some .verified)
-  let (res2, t2, l2) := enrichTransitiveVerification #[a2, b2, c2]
+  let (res2, t2, l2, _) := enrichTransitiveVerification #[a2, b2, c2]
   result ← test "all verified chain -> all transitively-verified"
     (getVS (findUA res2 "a").get! == some .transitivelyVerified &&
      getVS (findUA res2 "b").get! == some .transitivelyVerified &&
@@ -2187,7 +2187,7 @@ def testTransitiveVerificationBasic (result : TestResult) : IO TestResult := do
   -- One dep failed -> caller stays verified (locally)
   let a3 := mkUnified "a" #["b"] (some .verified)
   let b3 := mkUnified "b" #[] (some .failed)
-  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  let (res3, _, _, _) := enrichTransitiveVerification #[a3, b3]
   result ← test "dep failed -> caller stays verified"
     (getVS (findUA res3 "a").get! == some .verified) result
   result ← test "failed dep unchanged"
@@ -2196,7 +2196,7 @@ def testTransitiveVerificationBasic (result : TestResult) : IO TestResult := do
   -- One dep unverified -> caller stays verified (locally)
   let a4 := mkUnified "a" #["b"] (some .verified)
   let b4 := mkUnified "b" #[] (some .unverified)
-  let (res4, _, _) := enrichTransitiveVerification #[a4, b4]
+  let (res4, _, _, _) := enrichTransitiveVerification #[a4, b4]
   result ← test "dep unverified -> caller stays verified"
     (getVS (findUA res4 "a").get! == some .verified) result
   result ← test "unverified dep unchanged"
@@ -2211,20 +2211,30 @@ def testTransitiveVerificationTrust (result : TestResult) : IO TestResult := do
   -- Trusted dep does not block
   let a := mkUnified "a" #["b"] (some .verified)
   let b := mkUnified "b" #[] (some .trusted)
-  let (res, _, _) := enrichTransitiveVerification #[a, b]
+  let (res, _, _, md) := enrichTransitiveVerification #[a, b]
   result ← test "trusted dep -> caller transitively-verified"
     (getVS (findUA res "a").get! == some .transitivelyVerified) result
+  result ← test "no missing deps when all present"
+    (md == #[]) result
 
   -- Missing dep (not in map) does not block
   let a2 := mkUnified "a" #["nonexistent"] (some .verified)
-  let (res2, _, _) := enrichTransitiveVerification #[a2]
+  let (res2, _, _, md2) := enrichTransitiveVerification #[a2]
   result ← test "missing dep -> caller transitively-verified"
     (getVS (findUA res2 "a").get! == some .transitivelyVerified) result
+  result ← test "missing dep reported"
+    (md2 == #["nonexistent"]) result
+
+  -- Multiple missing deps are sorted and deduplicated
+  let a2b := mkUnified "a" #["z_missing", "a_missing", "z_missing"] (some .verified)
+  let (_, _, _, md2b) := enrichTransitiveVerification #[a2b]
+  result ← test "multiple missing deps sorted and deduped"
+    (md2b == #["a_missing", "z_missing"]) result
 
   -- Missing status does not contaminate
   let a3 := mkUnified "a" #["b"] (some .verified)
   let b3 := mkUnified "b" #[] none
-  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  let (res3, _, _, _) := enrichTransitiveVerification #[a3, b3]
   result ← test "missing status dep -> caller transitively-verified"
     (getVS (findUA res3 "a").get! == some .transitivelyVerified) result
 
@@ -2232,7 +2242,7 @@ def testTransitiveVerificationTrust (result : TestResult) : IO TestResult := do
   let a4 := mkUnified "a" #[] (some .unverified)
   let b4 := mkUnified "b" #[] (some .failed)
   let c4 := mkUnified "c" #[] none
-  let (res4, _, _) := enrichTransitiveVerification #[a4, b4, c4]
+  let (res4, _, _, _) := enrichTransitiveVerification #[a4, b4, c4]
   result ← test "unverified atom untouched"
     (getVS (findUA res4 "a").get! == some .unverified) result
   result ← test "failed atom untouched"
@@ -2250,7 +2260,7 @@ def testTransitiveVerificationGraph (result : TestResult) : IO TestResult := do
   let a := mkUnified "a" #["b"] (some .verified)
   let b := mkUnified "b" #["c"] (some .verified)
   let c := mkUnified "c" #[] (some .unverified)
-  let (res, _, _) := enrichTransitiveVerification #[a, b, c]
+  let (res, _, _, _) := enrichTransitiveVerification #[a, b, c]
   result ← test "transitive chain: A stays verified"
     (getVS (findUA res "a").get! == some .verified) result
   result ← test "transitive chain: B stays verified"
@@ -2263,7 +2273,7 @@ def testTransitiveVerificationGraph (result : TestResult) : IO TestResult := do
   let b2 := mkUnified "b" #["d"] (some .verified)
   let c2 := mkUnified "c" #["d"] (some .verified)
   let d2 := mkUnified "d" #[] (some .unverified)
-  let (res2, _, _) := enrichTransitiveVerification #[a2, b2, c2, d2]
+  let (res2, _, _, _) := enrichTransitiveVerification #[a2, b2, c2, d2]
   result ← test "diamond: A stays verified"
     (getVS (findUA res2 "a").get! == some .verified) result
   result ← test "diamond: B stays verified"
@@ -2276,7 +2286,7 @@ def testTransitiveVerificationGraph (result : TestResult) : IO TestResult := do
   -- Cycle (all verified) -> transitively-verified
   let a3 := mkUnified "a" #["b"] (some .verified)
   let b3 := mkUnified "b" #["a"] (some .verified)
-  let (res3, _, _) := enrichTransitiveVerification #[a3, b3]
+  let (res3, _, _, _) := enrichTransitiveVerification #[a3, b3]
   result ← test "cycle all verified: A transitively-verified"
     (getVS (findUA res3 "a").get! == some .transitivelyVerified) result
   result ← test "cycle all verified: B transitively-verified"
@@ -2287,7 +2297,7 @@ def testTransitiveVerificationGraph (result : TestResult) : IO TestResult := do
   let b4 := mkUnified "b" #["c", "d"] (some .verified)
   let c4 := mkUnified "c" #["a"] (some .verified)
   let d4 := mkUnified "d" #[] (some .unverified)
-  let (res4, _, _) := enrichTransitiveVerification #[a4, b4, c4, d4]
+  let (res4, _, _, _) := enrichTransitiveVerification #[a4, b4, c4, d4]
   result ← test "cycle with unverified: A stays verified"
     (getVS (findUA res4 "a").get! == some .verified) result
   result ← test "cycle with unverified: B stays verified"
@@ -2304,8 +2314,8 @@ def testTransitiveVerificationProperties (result : TestResult) : IO TestResult :
   -- Idempotency
   let a := mkUnified "a" #["b"] (some .verified)
   let b := mkUnified "b" #[] (some .unverified)
-  let (res1, _, _) := enrichTransitiveVerification #[a, b]
-  let (res2, _, _) := enrichTransitiveVerification res1
+  let (res1, _, _, _) := enrichTransitiveVerification #[a, b]
+  let (res2, _, _, _) := enrichTransitiveVerification res1
   result ← test "idempotency: A unchanged after second run"
     (getVS (findUA res2 "a").get! == getVS (findUA res1 "a").get!) result
   result ← test "idempotency: B unchanged after second run"
@@ -2313,8 +2323,8 @@ def testTransitiveVerificationProperties (result : TestResult) : IO TestResult :
 
   -- Idempotency for transitively-verified
   let c := mkUnified "c" #[] (some .verified)
-  let (res3, _, _) := enrichTransitiveVerification #[c]
-  let (res4, _, _) := enrichTransitiveVerification res3
+  let (res3, _, _, _) := enrichTransitiveVerification #[c]
+  let (res4, _, _, _) := enrichTransitiveVerification res3
   result ← test "idempotency: transitively-verified stays"
     (getVS (findUA res4 "c").get! == some .transitivelyVerified) result
 
@@ -2322,14 +2332,14 @@ def testTransitiveVerificationProperties (result : TestResult) : IO TestResult :
   let a5 := mkUnified "a" #[] (some .verified)
   let b5 := mkUnified "b" #["c"] (some .verified)
   let c5 := mkUnified "c" #[] (some .unverified)
-  let (_, t5, l5) := enrichTransitiveVerification #[a5, b5, c5]
+  let (_, t5, l5, _) := enrichTransitiveVerification #[a5, b5, c5]
   result ← test "counts: transitive=1, local=1" (t5 == 1 && l5 == 1) result
 
   -- Explicit unverified contaminates but missing does not
   let a6 := mkUnified "a" #["b", "c"] (some .verified)
   let b6 := mkUnified "b" #[] (some .unverified)
   let c6 := mkUnified "c" #[] none
-  let (res6, _, _) := enrichTransitiveVerification #[a6, b6, c6]
+  let (res6, _, _, _) := enrichTransitiveVerification #[a6, b6, c6]
   result ← test "explicit unverified contaminates, missing does not"
     (getVS (findUA res6 "a").get! == some .verified) result
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: ''
   extract-args:
-    description: 'Extra arguments passed to probe-lean extract (e.g., --skip-verify --library Lib1)'
+    description: 'Extra arguments passed to probe-lean extract (e.g., --skip-verify --skip-enrich --library Lib1)'
     required: false
     default: ''
   output-dir:

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,7 +1,7 @@
 # Schema 2.0: Lean Instantiation
 
 Version: 2.0
-Date: 2026-03-07
+Date: 2026-05-22
 Parent document: [probes/docs/envelope-rationale.md](https://github.com/Beneficial-AI-Foundation/probe/blob/main/docs/envelope-rationale.md)
 
 This document defines the Lean-specific details for Schema 2.0 as produced by `probe-lean`.
@@ -291,7 +291,7 @@ Each value contains all atom fields plus verification status and specs:
 | `rust-source` | string or null | Rust source path from Aeneas docstring |
 | `specs` | array or absent | Code-names of theorem atoms whose dependencies include this atom. Absent when empty. Whether an atom is "specified" can be inferred from `specs` being non-empty. |
 | `primary-spec` | string or absent | Code-name of the primary specification theorem for this atom. Absent when none. Determined by precedence: (1) `@[primary_spec]` attribute, (2) known verification-framework attributes (`@[progress]`, `@[pspec]`, `@[step]`), (3) `_spec` suffix match, (4) sole spec inference. |
-| `verification-status` | string or absent | `"verified"`, `"unverified"`, `"failed"`, `"trusted"`, or absent if skipped. Verification is **shallow**: it reflects whether the declaration's own body contains `sorry`, but does not check whether any of its dependencies are unverified. Axioms, declarations carrying `@[externally_verified]`, and non-theorem declarations from `*External.lean` files (Aeneas trust base) are always `"trusted"`. Theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal status from sorry detection. Declarations without source location (kernel-synthesized) are filtered from output entirely. |
+| `verification-status` | string or absent | `"transitively-verified"`, `"verified"`, `"unverified"`, `"failed"`, `"trusted"`, or absent if skipped. A declaration is `"verified"` if its own body does not contain `sorry`; it is upgraded to `"transitively-verified"` if, additionally, all its transitive dependencies are verified or trusted (computed via reverse-BFS contamination, skippable with `--skip-enrich`). Declarations that are locally sorry-free but have at least one unverified or failed transitive dependency remain `"verified"`. Axioms, declarations carrying `@[externally_verified]`, and non-theorem declarations from `*External.lean` files (Aeneas trust base) are always `"trusted"`. Theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal status from sorry detection. Declarations without source location (kernel-synthesized) are filtered from output entirely. |
 | `trusted-reason` | string or absent | Present only when `verification-status` is `"trusted"`. Values: `"axiom"` (Lean `axiom` keyword), `"externally_verified"` (declaration tagged `@[externally_verified]` — proof discharged outside Lean), `"external"` (non-theorem declaration in a file ending with `External.lean`). Enables automated trust-base classification. |
 
 ### `probe-lean/viewify` (molecules)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,6 +71,7 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 | `--library <LIBS>` | `-l` | Comma-separated list of library names to build (default: `defaultTargets` from `lakefile.toml`, falling back to all `[[lean_lib]]` entries) |
 | `--skip-verify` | | Skip the sorry detection step (graph structure only) |
 | `--from-file <FILE>` | | Use existing build output for sorry detection instead of running lake |
+| `--skip-enrich` | | Skip transitive verification enrichment (no `"transitively-verified"` status) |
 
 ---
 
@@ -257,7 +258,7 @@ The `extract` command produces a JSON file wrapped in a Schema 2.0 metadata enve
 {
   "schema": "probe-lean/extract",
   "schema-version": "2.0",
-  "tool": { "name": "probe-lean", "version": "0.4.5", "command": "extract" },
+  "tool": { "name": "probe-lean", "version": "0.7.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
     "commit": "abc123d",

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.6.3"
+version = "0.7.0"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
## Summary

- Ports the reverse-BFS contamination algorithm from `probe`'s `propagate.rs` to Lean (`ProbeLean/Transitive.lean`), matching the `transitively-verified` status already present in `probe-verus` and `probe-aeneas`
- Verified atoms whose transitive dependencies are all verified or trusted are upgraded to `"transitively-verified"`; atoms that are locally sorry-free but have at least one unverified/failed transitive dependency remain `"verified"`
- Adds `--skip-enrich` CLI flag to opt out of the enrichment step

## Changes

| File | Change |
|------|--------|
| `ProbeLean/Transitive.lean` | **New** — reverse-BFS contamination using `Lean.RBMap` + `Array`-backed queue |
| `ProbeLean/Types.lean` | Added `transitivelyVerified` variant + JSON serde |
| `ProbeLean/Extract.lean` | Added `skipEnrich` to config, wired enrich step after merge |
| `ProbeLean/Main.lean` | Added `--skip-enrich` CLI flag |
| `ProbeLean.lean` | Registered new module import |
| `Tests/Main.lean` | 30 new tests (basic, trust, graph patterns, properties, JSON round-trip) |
| `lakefile.toml` + `ProbeLean/Version.lean` | Version 0.6.3 → 0.7.0 |
| Docs | SCHEMA.md, README.md, USAGE.md, CLAUDE.md, CHANGELOG.md, action.yml updated |

## Test plan

- [x] `lake build` succeeds (37 jobs)
- [x] `lake build tests && .lake/build/bin/tests` — 381 passed, 0 failed
- [x] All 13 plan-specified test cases covered (leaf, chain, diamond, cycle, trust, missing, idempotency, etc.)
- [x] JSON round-trip for `"transitively-verified"` enum value
- [x] `validStatuses` lists updated in example-JSON and invariant tests
- [x] Ralph Loop clean (code quality, test quality, ambiguity auditors)

closes https://github.com/Beneficial-AI-Foundation/probe-lean/issues/35

Made with [Cursor](https://cursor.com)