### PR TITLE
feat(classify): security-protocol classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-16
+
+### Added
+
+- **Security-protocol classification**: for VCVio-based cryptographic projects, `extract` now
+  classifies each declaration into a `scheme → construction → {correctness, security}` hierarchy
+  so a consumer can render an accordion. Two additive, optional fields:
+  - envelope **`source.class`** (`"security-protocol"`), resolved by precedence: `--class` override
+    > Lake manifest (package-level VCVio dependency) > imported-module signal;
+  - per-atom **`classification`** — `{ category, via, scheme?, construction? }`, where `category`
+    is `scheme`/`construction`/`correctness`/`security`/`ambiguous`, `via` records the signal tier
+    (`attribute`/`type`/`naming`), and the `scheme`/`construction` links are resolved fail-closed.
+  Detection cascade is attribute > type > naming; project-own property definitions are promoted to
+  anchors; theorems are classified by a bounded reachability walk. `ambiguous` flags a property
+  whose correctness-vs-security axis is undecided (equal-depth tie or conflicting tags).
+  See [docs/classification-security-protocol.md](docs/classification-security-protocol.md).
+- **Classification attributes** (`ProbeLean.Attrs`): `@[scheme_def]`, `@[construction_def]`,
+  `@[correctness_spec]`, `@[security_spec]` — authoritative overrides for projects whose schemes or
+  properties are not conventionally named.
+- **`--class <name>` flag** on `extract`: override the detected project class for manual runs.
+
+### Unchanged
+
+- Non-security-protocol projects are unchanged from 0.7.0 apart from `tool.version`/timestamp
+  metadata (no class detected → neither `source.class` nor `classification` is emitted).
+
 ## [0.7.0] - 2026-05-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,9 @@ Do **not** hardcode version strings anywhere else — use `ProbeLean.version` (o
 - `ProbeLean/Version.lean` — Single version constant, generated from `lakefile.toml`
 - `ProbeLean/Types.lean` — All data structures and JSON serialization
 - `ProbeLean/View.lean` — `viewify` command (filters atoms → molecules for web UI)
+- `ProbeLean/Attrs.lean` — Shared tag attributes (`@[primary_spec]`, `@[externally_verified]`, and the security-protocol tags `@[scheme_def]`/`@[construction_def]`/`@[correctness_spec]`/`@[security_spec]`)
+- `ProbeLean/Classify/Catalogue.lean` — VCVio anchor catalogue (FQN sets) + drift diagnostic, for security-protocol classification
+- `ProbeLean/Classify/SecurityProtocol.lean` — Pure classifier: `scheme → construction → {correctness, security}` (run from `runAnalysisViaLakeEnv` when the `security-protocol` class is detected)
 
 ### Key design decisions
 

--- a/ProbeLean.lean
+++ b/ProbeLean.lean
@@ -10,3 +10,4 @@ import ProbeLean.Transitive
 import ProbeLean.Extract
 import ProbeLean.View
 import ProbeLean.Classify.Catalogue
+import ProbeLean.Classify.SecurityProtocol

--- a/ProbeLean.lean
+++ b/ProbeLean.lean
@@ -9,3 +9,4 @@ import ProbeLean.VerifyInternal
 import ProbeLean.Transitive
 import ProbeLean.Extract
 import ProbeLean.View
+import ProbeLean.Classify.Catalogue

--- a/ProbeLean/Analysis.lean
+++ b/ProbeLean/Analysis.lean
@@ -188,6 +188,114 @@ def isRelevantSource (source : Option String) (crate : String) : Bool :=
     !s.startsWith "/" &&  -- External paths start with /rustc/ or /cargo/
     !containsSubstring s "/cargo/registry/"
 
+-- ============================================================
+-- Security-protocol classification facts (pure, .olean-derived)
+-- These facts are computed here so the pure classifier (Commit 4) can consume
+-- them without re-walking the environment. See
+-- docs/classification-security-protocol.md.
+-- ============================================================
+
+/-- Structural shape of a declaration's result type (codomain). Used as a
+*type* signal by the classifier. Computed by naive `Expr` inspection (no
+`whnf`); the validation gate decides whether reducible-alias unfolding is
+needed. -/
+inductive CodomainShape where
+  | prop       -- result is `Sort 0` (a predicate, when the decl is a `def`)
+  | game       -- probabilistic computation returning `Bool` (a security/correctness game)
+  | advantage  -- result head is a probability/real type
+  | other
+  deriving Repr, BEq, Inhabited
+
+instance : ToString CodomainShape where
+  toString
+    | .prop => "prop"
+    | .game => "game"
+    | .advantage => "advantage"
+    | .other => "other"
+
+/-- Strip leading `∀`/`→` binders, returning the result type. The body may
+contain loose bvars, but head/last-arg inspection does not look inside them. -/
+partial def stripForalls : Expr → Expr
+  | .forallE _ _ body _ => stripForalls body
+  | e => e
+
+/-- The head constant of a declaration's result type, if any. Approximate — it
+does not unfold reducible aliases (see the validation gate). -/
+def codomainHeadOf (type : Expr) : Option Name :=
+  match (stripForalls type).getAppFn with
+  | .const n _ => some n
+  | _ => none
+
+/-- Result-type head constants that mark an *advantage* (a probability bound).
+Mathlib-fixed, so inlined rather than catalogued. -/
+def advantageHeads : Array Name := #[`Real, `ENNReal, `NNReal]
+
+/-- Default probabilistic-computation head constants that make a `… → Bool`
+result a *game*. Minimal placeholder; Commit 3's catalogue supersedes/extends
+this against the VCVio commit the protocol repos pin. -/
+def defaultGameHeads : Array Name := #[`ProbComp, `OracleComp, `SPMF]
+
+/-- True when the final application argument of `e` is the constant `Bool`. -/
+def lastArgIsBool (e : Expr) : Bool :=
+  match e.getAppArgs.back? with
+  | some (.const n _) => n == `Bool
+  | _ => false
+
+/-- Classify the shape of a result type. `gameHeads` is the allowlist of
+probabilistic-computation head constants (so the pure function is testable and
+the catalogue is injectable). The "final arg is `Bool`" check alone overmatches
+(`List Bool`, `Array Bool`, `Except ε Bool`), so the head must be in the
+allowlist for the `game` verdict. -/
+def classifyCodomain (gameHeads : Array Name) (type : Expr) : CodomainShape :=
+  let result := stripForalls type
+  match result with
+  | .sort .zero => .prop
+  | _ =>
+    match result.getAppFn with
+    | .const n _ =>
+      if advantageHeads.contains n then .advantage
+      else if gameHeads.contains n && lastArgIsBool result then .game
+      else .other
+    | _ => .other
+
+/-- Handle-based detection (pure, `env`-only) of the four classification tags.
+Works when the target project imports `ProbeLean.Attrs`. -/
+def detectClassAttrs (env : Environment) (name : Name) : Array String := Id.run do
+  let mut a : Array String := #[]
+  if schemeDefAttr.hasTag env name then a := a.push "scheme_def"
+  if constructionDefAttr.hasTag env name then a := a.push "construction_def"
+  if correctnessSpecAttr.hasTag env name then a := a.push "correctness_spec"
+  if securitySpecAttr.hasTag env name then a := a.push "security_spec"
+  return a
+
+/-- Decide whether a list of (imported) module names indicates a VCVio-based
+security-protocol project. Factored out so it is testable without an
+`Environment`. -/
+def moduleListIndicatesSecurityProtocol (mods : Array Name) : Bool :=
+  mods.any fun m => m == `VCVio || m.toString.startsWith "VCVio."
+
+/-- Detect the project class from the imported environment (import-level signal).
+Returns `none` when no class is detected. -/
+def detectClass (env : Environment) : Option String :=
+  if moduleListIndicatesSecurityProtocol env.allImportedModuleNames then
+    some "security-protocol"
+  else
+    none
+
+/-- Package-level class detection from `lake-manifest.json`. This is independent
+of which modules were selected for analysis (so it does not false-negative when
+a `--module`/`--library` slice happens not to import VCVio) and confirms the
+dependency is actually declared (so a project-owned `VCVio.*` module does not
+trigger a false positive). Mirrors `ensureMathlibCache`'s substring approach;
+matches the VCVio package name or its git url. -/
+def detectClassFromManifest (projectPath : System.FilePath) : IO (Option String) := do
+  let manifestPath := projectPath / "lake-manifest.json"
+  if !(← manifestPath.pathExists) then return none
+  let content ← IO.FS.readFile manifestPath
+  if containsSubstring content "\"VCVio\"" || containsSubstring content "VCV-io" then
+    return some "security-protocol"
+  return none
+
 /-- Information about a declaration for analysis -/
 structure DeclInfo where
   name : Name
@@ -198,9 +306,19 @@ structure DeclInfo where
   typeDependencies : Array Name
   termDependencies : Array Name
   sourceInfo : Option CodeTextInfo
+  /-- Result-type head constant (approximate; see `codomainHeadOf`). -/
+  codomainHead : Option Name := none
+  /-- Structural shape of the result type (see `classifyCodomain`). -/
+  codomainShape : CodomainShape := .other
+  /-- Handle-detected classification tags present on the declaration
+      (the four class tags only; distinct from the emitted `Atom.attributes`). -/
+  classAttributes : Array String := #[]
 
-/-- Analyze a single declaration -/
-def analyzeDecl (env : Environment) (name : Name) (info : ConstantInfo) : DeclInfo :=
+/-- Analyze a single declaration. `gameHeads` is the probabilistic-computation
+head allowlist used to compute `codomainShape`; it is injected so Commit 3 can
+supply the catalogue's set in place of `defaultGameHeads`. -/
+def analyzeDecl (env : Environment) (name : Name) (info : ConstantInfo)
+    (gameHeads : Array Name := defaultGameHeads) : DeclInfo :=
   let displayName := getDisplayName name
   let moduleName := getModuleName env name |>.getD .anonymous
   let kind := getDeclKind env name info
@@ -210,10 +328,15 @@ def analyzeDecl (env : Environment) (name : Name) (info : ConstantInfo) : DeclIn
     dependencies := deps.all,
     typeDependencies := deps.typeDeps,
     termDependencies := deps.termDeps,
-    sourceInfo }
+    sourceInfo,
+    codomainHead := codomainHeadOf info.type,
+    codomainShape := classifyCodomain gameHeads info.type,
+    classAttributes := detectClassAttrs env name }
 
-/-- Get all project declarations from an environment -/
-def getProjectDecls (env : Environment) (projectModules : Array Name) : Array DeclInfo := Id.run do
+/-- Get all project declarations from an environment. `gameHeads` is threaded to
+`analyzeDecl` for `codomainShape` (default placeholder until Commit 3's catalogue). -/
+def getProjectDecls (env : Environment) (projectModules : Array Name)
+    (gameHeads : Array Name := defaultGameHeads) : Array DeclInfo := Id.run do
   let mut decls : Array DeclInfo := #[]
   for (name, info) in env.constants.map₁.toList do
     -- Skip internal names
@@ -227,7 +350,7 @@ def getProjectDecls (env : Environment) (projectModules : Array Name) : Array De
     | .ctorInfo _ => continue
     | .recInfo _ => continue
     | _ => pure ()
-    let decl := analyzeDecl env name info
+    let decl := analyzeDecl env name info gameHeads
     -- Skip declarations without source location (auto-generated by the kernel)
     if decl.sourceInfo.isNone then
       continue

--- a/ProbeLean/Analysis.lean
+++ b/ProbeLean/Analysis.lean
@@ -282,19 +282,35 @@ def detectClass (env : Environment) : Option String :=
   else
     none
 
-/-- Package-level class detection from `lake-manifest.json`. This is independent
-of which modules were selected for analysis (so it does not false-negative when
-a `--module`/`--library` slice happens not to import VCVio) and confirms the
-dependency is actually declared (so a project-owned `VCVio.*` module does not
-trigger a false positive). Mirrors `ensureMathlibCache`'s substring approach;
-matches the VCVio package name or its git url. -/
+/-- Does a `lake-manifest.json` body declare a **direct** VCVio dependency? We
+parse the JSON and require a `packages[]` entry with `name == "VCVio"` **and**
+`inherited == false` — a direct dep, not one pulled in transitively (those are
+`inherited: true`, e.g. via Mathlib). This avoids false positives from transitive
+deps, git urls, or comments. Unparseable JSON ⇒ `false` (the import-graph signal
+in `detectClass` still backstops). Pure, so it is unit-testable. -/
+def manifestDeclaresVCVio (content : String) : Bool :=
+  match Lean.Json.parse content with
+  | .error _ => false
+  | .ok json =>
+    let pkgs := (json.getObjValAs? (Array Lean.Json) "packages").toOption.getD #[]
+    pkgs.any fun p =>
+      let inherited := (p.getObjValAs? Bool "inherited").toOption.getD true
+      (p.getObjValAs? String "name").toOption.getD "" == "VCVio" && !inherited
+
+/-- Package-level class detection from `lake-manifest.json`: a **direct**
+(non-inherited) VCVio dependency ⇒ `security-protocol`. Independent of which
+modules were selected for analysis (so it does not false-negative when a
+`--module`/`--library` slice happens not to import VCVio). Manifest problems
+fail closed *consistently*: a missing, unreadable, or unparseable manifest ⇒
+`none`, so detection falls back to the import-graph signal rather than aborting
+extraction. -/
 def detectClassFromManifest (projectPath : System.FilePath) : IO (Option String) := do
   let manifestPath := projectPath / "lake-manifest.json"
   if !(← manifestPath.pathExists) then return none
-  let content ← IO.FS.readFile manifestPath
-  if containsSubstring content "\"VCVio\"" || containsSubstring content "VCV-io" then
-    return some "security-protocol"
-  return none
+  -- Read can still fail (permissions, a TOCTOU delete after `pathExists`, a
+  -- flaky mount); treat that like an unparseable manifest and fall back.
+  let content ← try IO.FS.readFile manifestPath catch _ => return none
+  return if manifestDeclaresVCVio content then some "security-protocol" else none
 
 /-- Information about a declaration for analysis -/
 structure DeclInfo where

--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -6,6 +6,7 @@ import Lean
 import ProbeLean.Types
 import ProbeLean.Environment
 import ProbeLean.Analysis
+import ProbeLean.Classify.SecurityProtocol
 
 namespace ProbeLean
 
@@ -193,15 +194,39 @@ def findProbeLeanLib : IO (List System.FilePath) := do
   if ← lakeBuildLib.pathExists then paths := lakeBuildLib :: paths
   return paths
 
+/-- The security-protocol classifier runs **only** for this class — other/unknown
+    class values (e.g. a `--class` override for a class with no classifier yet)
+    carry no classification, keeping the dispatch forward-compatible. -/
+def isSecurityProtocolClass : Option String → Bool
+  | some "security-protocol" => true
+  | _ => false
+
+/-- Run the security-protocol classifier (when the class matches), emitting tag
+    diagnostics and catalogue-drift warnings to stderr. Returns the
+    `(name, classification)` pairs (empty for other/no class). -/
+def classifyProject (env : Environment) (decls : Array DeclInfo)
+    (detectedClass : Option String) : IO (Array (Name × Classification)) := do
+  if !isSecurityProtocolClass detectedClass then return #[]
+  let (classifications, diags) := Classify.classify decls
+  for d in diags do
+    IO.eprintln s!"Warning: classification: {d}"
+  let drifts := Catalogue.driftWarnings env
+  unless drifts.isEmpty do
+    IO.eprintln s!"Warning: {drifts.size} classification-catalogue drift warning(s):"
+    for w in drifts do
+      IO.eprintln s!"  {w}"
+  IO.println s!"Classified {classifications.size} declarations"
+  return classifications
+
 /-- Run analysis via lake env to get correct search paths.
-    Returns the atoms together with the effective project class (`none` when no
-    class is detected). The class is resolved here — where both the environment
-    and the project path are available — so a later classifier pass can gate on
-    it. Precedence: `classOverride` (from `--class`) > `lake-manifest.json`
-    (package-level) > imported-module signal. -/
+    Returns the atoms, the effective project class (`none` when no class is
+    detected), and the per-declaration classifications (empty when no class).
+    The class is resolved here — where both the environment and the project path
+    are available. Precedence: `classOverride` (from `--class`) >
+    `lake-manifest.json` (package-level) > imported-module signal. -/
 def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name) (crate : String)
     (nixMode : Option NixMode := none) (classOverride : Option String := none)
-    : IO (Except String (Array Atom × Option String)) := do
+    : IO (Except String (Array Atom × Option String × Array (Name × Classification))) := do
   let absProjectPath ← IO.FS.realPath projectPath
 
   Lean.initSearchPath (← Lean.findSysroot)
@@ -252,7 +277,8 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name)
 
   IO.println "Extracting declarations..."
 
-  let decls := getProjectDecls env modules
+  -- Use the catalogue's game-head allowlist for codomain-shape (not the placeholder).
+  let decls := getProjectDecls env modules Catalogue.gameHeads
 
   IO.println s!"Found {decls.size} declarations"
 
@@ -264,12 +290,14 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name)
   | some c => IO.println s!"Project class: {c}"
   | none => pure ()
 
+  let classifications ← classifyProject env decls detectedClass
+
   let fileCache : FileCache ← IO.mkRef {}
   let mut atoms : Array Atom := #[]
   for decl in decls do
     let atom ← declInfoToAtom env projectPath modules crate fileCache decl
     atoms := atoms.push atom
 
-  return .ok (atoms, detectedClass)
+  return .ok (atoms, detectedClass, classifications)
 
 end ProbeLean

--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -283,6 +283,11 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name)
   IO.println s!"Found {decls.size} declarations"
 
   -- Effective class: --class override > manifest (package-level) > imported modules.
+  -- This is a disjunction (`orElse`): any positive signal classifies, so the order
+  -- does not affect false positives — only each signal's precision does (the
+  -- manifest signal fires only on a *direct* VCVio dep; see `detectClassFromManifest`).
+  -- Manifest-first preserves filter-independence: a `--module` slice that doesn't
+  -- import VCVio still classifies via the package-level manifest.
   let manifestClass ← detectClassFromManifest projectPath
   let detectedClass := classOverride.orElse fun () =>
     manifestClass.orElse fun () => detectClass env

--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -193,9 +193,15 @@ def findProbeLeanLib : IO (List System.FilePath) := do
   if ← lakeBuildLib.pathExists then paths := lakeBuildLib :: paths
   return paths
 
-/-- Run analysis via lake env to get correct search paths -/
+/-- Run analysis via lake env to get correct search paths.
+    Returns the atoms together with the effective project class (`none` when no
+    class is detected). The class is resolved here — where both the environment
+    and the project path are available — so a later classifier pass can gate on
+    it. Precedence: `classOverride` (from `--class`) > `lake-manifest.json`
+    (package-level) > imported-module signal. -/
 def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name) (crate : String)
-    (nixMode : Option NixMode := none) : IO (Except String (Array Atom)) := do
+    (nixMode : Option NixMode := none) (classOverride : Option String := none)
+    : IO (Except String (Array Atom × Option String)) := do
   let absProjectPath ← IO.FS.realPath projectPath
 
   Lean.initSearchPath (← Lean.findSysroot)
@@ -250,12 +256,20 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name)
 
   IO.println s!"Found {decls.size} declarations"
 
+  -- Effective class: --class override > manifest (package-level) > imported modules.
+  let manifestClass ← detectClassFromManifest projectPath
+  let detectedClass := classOverride.orElse fun () =>
+    manifestClass.orElse fun () => detectClass env
+  match detectedClass with
+  | some c => IO.println s!"Project class: {c}"
+  | none => pure ()
+
   let fileCache : FileCache ← IO.mkRef {}
   let mut atoms : Array Atom := #[]
   for decl in decls do
     let atom ← declInfoToAtom env projectPath modules crate fileCache decl
     atoms := atoms.push atom
 
-  return .ok atoms
+  return .ok (atoms, detectedClass)
 
 end ProbeLean

--- a/ProbeLean/Attrs.lean
+++ b/ProbeLean/Attrs.lean
@@ -1,7 +1,9 @@
 /-
   Shared attributes for probe-lean.
-  Target projects import this module to use `@[primary_spec]` and
-  `@[externally_verified]`.
+  Target projects import this module to use `@[primary_spec]`,
+  `@[externally_verified]`, and the security-protocol classification tags
+  (`@[scheme_def]`, `@[construction_def]`, `@[correctness_spec]`,
+  `@[security_spec]`).
 -/
 import Lean
 
@@ -22,5 +24,34 @@ been verified externally (e.g., in Verus or another prover). Consumed by
 initialize externallyVerifiedAttr : TagAttribute ←
   registerTagAttribute `externally_verified
     "Marks a theorem as externally verified (sorry is intentional)."
+
+-- ============================================================
+-- Security-protocol classification tags (authoritative `via: attribute`).
+-- See docs/classification-security-protocol.md.
+-- ============================================================
+
+/-- `@[scheme_def]` marks a declaration as a cryptographic *scheme* — the
+abstract interface (a `structure`/`class` bundling operations). -/
+initialize schemeDefAttr : TagAttribute ←
+  registerTagAttribute `scheme_def
+    "Marks a declaration as a cryptographic scheme (abstract interface)."
+
+/-- `@[construction_def]` marks a declaration as a concrete *construction* —
+a definition realising a scheme. -/
+initialize constructionDefAttr : TagAttribute ←
+  registerTagAttribute `construction_def
+    "Marks a declaration as a concrete construction of a scheme."
+
+/-- `@[correctness_spec]` marks a declaration (game, predicate, or theorem) as
+a *correctness* property of a construction or scheme. -/
+initialize correctnessSpecAttr : TagAttribute ←
+  registerTagAttribute `correctness_spec
+    "Marks a declaration as a correctness property."
+
+/-- `@[security_spec]` marks a declaration (game, advantage, or theorem) as a
+*security* property of a construction or scheme. -/
+initialize securitySpecAttr : TagAttribute ←
+  registerTagAttribute `security_spec
+    "Marks a declaration as a security property."
 
 end ProbeLean

--- a/ProbeLean/Classify/Catalogue.lean
+++ b/ProbeLean/Classify/Catalogue.lean
@@ -2,8 +2,9 @@
   Classification catalogue for VCVio-based security-protocol projects.
 
   Fully-qualified VCVio anchor names consumed by the security-protocol
-  classifier (Commit 4). Enumerated against **VCVio commit `ebea2fa`** — the
-  revision the protocol model repos pin in their `lake-manifest.json`. Names are
+  classifier (Commit 4). Enumerated against **VCVio commit `ebea2fa`**; target
+  repos may pin a newer, divergent VCVio (e.g. secure-messaging pins `1e984d2`),
+  against which these FQNs were re-verified to resolve cleanly. Names are
   baked as Lean literals (no external config file). FQNs were verified by reading
   the pinned source (`section`s are transparent; only `namespace` affects names).
 

--- a/ProbeLean/Classify/Catalogue.lean
+++ b/ProbeLean/Classify/Catalogue.lean
@@ -1,0 +1,149 @@
+/-
+  Classification catalogue for VCVio-based security-protocol projects.
+
+  Fully-qualified VCVio anchor names consumed by the security-protocol
+  classifier (Commit 4). Enumerated against **VCVio commit `ebea2fa`** — the
+  revision the protocol model repos pin in their `lake-manifest.json`. Names are
+  baked as Lean literals (no external config file). FQNs were verified by reading
+  the pinned source (`section`s are transparent; only `namespace` affects names).
+
+  These are illustrative *anchors*, not an exhaustive census: project theorems
+  are usually anchored on project-own games (classified by naming and promoted),
+  so the catalogue is a secondary safety net. The drift diagnostic
+  (`driftWarnings`) surfaces catalogue staleness against a different VCVio
+  version. See docs/classification-security-protocol.md.
+-/
+import Lean
+
+namespace ProbeLean.Catalogue
+
+open Lean
+
+-- ============================================================
+-- Anchor sets (VCVio @ ebea2fa)
+-- ============================================================
+
+/-- VCVio scheme *interface* types (structures/abbrevs bundling algorithm
+operations). A project `def` whose return-type head is one of these is a
+**construction**. `PKE_Alg` is an `abbrev` for `AsymmEncAlg`; because the naive
+`codomainHeadOf` does not unfold aliases, both the alias head and the underlying
+structure are listed so a `def … : PKE_Alg …` still matches. -/
+def vcvioSchemeTypes : Array Name := #[
+  `SymmEncAlg, `AsymmEncAlg, `AsymmEncAlg.ExplicitCoins, `PKE_Alg,
+  `SignatureAlg, `KEMScheme, `PRFScheme, `PRGScheme,
+  `CommitmentScheme, `SigmaProtocol, `OneWay.TrapdoorPermutation, `GenerableRelation
+]
+
+/-- Probabilistic-computation head constants: a `… → Bool` result headed by one
+of these is a *game*. Base monads only — monad-transformer stacks over these
+(`StateT`/`OptionT`/`WriterT`, e.g. `AddWriterT ℕ m (Bool × ℕ)` in
+`Fischlin.lean`) are handled by the recognizer/naming path, not by adding
+transformer heads here (which would misclassify `StateT σ Id Bool`). -/
+def gameHeads : Array Name := #[`OracleComp, `ProbComp, `SPMF, `PMF]
+
+/-- VCVio **correctness** anchors — walk targets for the correctness category. -/
+def correctnessAnchors : Array Name := #[
+  `SymmEncAlg.Complete, `SymmEncAlg.CompleteExp,
+  `AsymmEncAlg.CorrectExp, `AsymmEncAlg.PerfectlyCorrect,
+  `SignatureAlg.PerfectlyComplete,
+  `KEMScheme.CorrectExp, `KEMScheme.PerfectlyCorrect,
+  `CommitmentScheme.PerfectlyCorrect,
+  `SigmaProtocol.PerfectlyComplete,
+  `OneWay.TrapdoorPermutation.Correct
+]
+
+/-- VCVio **security** anchors — walk targets for the security category: the
+security-experiment types, their advantages, and the per-primitive `*Advantage`,
+game, and soundness definitions. -/
+def securityAnchors : Array Name := #[
+  -- generic experiment / advantage machinery
+  `SecExp, `SecExp.advantage,
+  `SecurityExp, `SecurityExp.secure, `SecurityGame, `SecurityGame.secureAgainst,
+  `ProbComp.distAdvantage, `ProbComp.boolDistAdvantage,
+  `ProbComp.guessAdvantage, `ProbComp.boolBiasAdvantage,
+  -- asymmetric encryption: IND-CCA and IND-CPA families
+  `AsymmEncAlg.IND_CCA_Advantage,
+  `AsymmEncAlg.IND_CPA_advantage, `AsymmEncAlg.IND_CPA_signedAdvantageReal,
+  `AsymmEncAlg.IND_CPA_experiment, `AsymmEncAlg.IND_CPA_LR_experiment,
+  `AsymmEncAlg.IND_CPA_OneTime_Game, `AsymmEncAlg.IND_CPA_OneTime_Game_ProbComp,
+  `AsymmEncAlg.IND_CPA_OneTime_biasAdvantage, `AsymmEncAlg.IND_CPA_OneTime_signedAdvantageReal,
+  `AsymmEncAlg.ExplicitCoins.OW_CPA_Game, `AsymmEncAlg.ExplicitCoins.OW_CPA_Advantage,
+  -- symmetric encryption secrecy
+  `SymmEncAlg.perfectSecrecy, `SymmEncAlg.perfectSecrecyAt,
+  -- KEM / PRF / PRG
+  `KEMScheme.IND_CCA_Advantage, `PRFScheme.prfAdvantage, `PRGScheme.prgAdvantage,
+  -- commitments
+  `CommitmentScheme.hidingAdvantage, `CommitmentScheme.bindingAdvantage,
+  `CommitmentScheme.PerfectlyHiding,
+  -- signatures
+  `SignatureAlg.unforgeableAdv.advantage,
+  -- hardness assumptions
+  `OneWay.owfAdvantage, `OneWay.tdpAdvantage,
+  `DiffieHellman.ddhGuessAdvantage, `DiffieHellman.ddhDistAdvantage,
+  `EntropySmoothing.advantage,
+  `LearningWithErrors.advantage, `LearningWithErrors.searchAdvantage,
+  -- sigma protocols
+  `SigmaProtocol.SpeciallySound, `SigmaProtocol.SpeciallySoundAt,
+  `SigmaProtocol.HVZK, `SigmaProtocol.UniqueResponses
+]
+
+/-- Mathlib names that contain `Alg` but are algebraic structures, **not** crypto
+schemes. The scheme *naming* signal keys on `*Alg` (VCVio schemes are
+`SymmEncAlg`, `MacAlg`, …), which collides lexically with these.
+
+**Comparator contract (for Commit 4):** these are bare last-component names; the
+classifier must exclude a project declaration whose **last name component**
+(display name) matches one of these — *not* by full `Name` equality, since a
+project's algebra type carries its own namespace. -/
+def mathlibAlgebraGuard : Array Name := #[
+  `Algebra, `Subalgebra, `AlgHom, `AlgEquiv, `AlgebraMap,
+  `BoolAlg, `BooleanAlgebra, `FreeAlgebra, `TensorAlgebra,
+  `MonoidAlgebra, `AddMonoidAlgebra, `LieAlgebra, `NonUnitalAlgebra
+]
+
+/-- Every catalogued anchor (for the drift diagnostic). -/
+def allAnchors : Array Name :=
+  vcvioSchemeTypes ++ gameHeads ++ correctnessAnchors ++ securityAnchors
+
+-- ============================================================
+-- Drift diagnostic
+-- ============================================================
+
+/-- Generic resolver: a warning string for each FQN **absent** from the
+environment. Unconditional — exposed for manual audit and tests. -/
+def resolveAnchors (env : Environment) (fqns : Array Name) : Array String :=
+  fqns.filterMap fun n =>
+    if env.contains n then none
+    else some s!"classification catalogue: anchor not found in environment: {n}"
+
+/-- The *guard* for an anchor: the symbol whose presence indicates the anchor's
+family is loaded. We use the parent namespace — for a scheme-namespaced anchor
+(`KEMScheme.IND_CCA_Advantage`) that is the scheme structure (`KEMScheme`),
+which is loaded iff that primitive is imported. Top-level anchors (`SecExp`,
+`OracleComp`) have no usable guard (`none`) and are therefore *not*
+drift-checked — this is what avoids the false alarm for a project that imports
+only a slice of VCVio (e.g. KVAC imports `ProbComp` but not `SecExp`). -/
+def guardOf : Name → Option Name
+  | .str p _ => if p.isAnonymous then none else some p
+  | .num p _ => if p.isAnonymous then none else some p
+  | .anonymous => none
+
+/-- Family-conditional drift warnings: warn for an anchor only when its guard is
+loaded but the anchor itself is absent — i.e. the primitive is present yet the
+expected anchor name is not, the signature of an upstream rename.
+
+Best-effort and **informational**, not an error. It can over-report when a
+namespace spans several modules with optional imports (e.g. importing
+`AsymmEncAlg` core but not its `IND_CPA` submodule leaves the `AsymmEncAlg`
+guard satisfied while `AsymmEncAlg.IND_CPA_*` anchors are legitimately absent).
+Commit 5 emits these as diagnostics only when a class is detected. -/
+def driftWarnings (env : Environment) : Array String :=
+  allAnchors.filterMap fun a =>
+    match guardOf a with
+    | some g =>
+      if env.contains g && !env.contains a then
+        some s!"classification catalogue: '{a}' missing though '{g}' is loaded (VCVio drift?)"
+      else none
+    | none => none
+
+end ProbeLean.Catalogue

--- a/ProbeLean/Classify/SecurityProtocol.lean
+++ b/ProbeLean/Classify/SecurityProtocol.lean
@@ -1,0 +1,386 @@
+/-
+  Pure security-protocol classifier.
+
+  `classify : Array DeclInfo → Array (Name × Classification) × Array String`
+  assigns each project declaration a category (scheme / construction /
+  correctness / security / ambiguous) and resolves its hierarchy links, using
+  the facts on `DeclInfo` (kind, codomain shape/head, class tags, typed deps)
+  and the VCVio catalogue. Pure ⇒ unit-testable on hand-built `DeclInfo`.
+
+  Stages run in dependency order (each uses what the previous established):
+    1. schemes        — @[scheme_def] | *Scheme/*Alg naming (+ kind/algebra guard)
+    2. constructions  — return-type head is a scheme | @[construction_def]
+    3. property defs  — attr/naming classify & PROMOTE to anchors, then a
+                        type-reach fixed point (order-independent)
+    4. theorems       — attr | bounded BFS walk to nearest anchor | naming
+
+  A genuine equal-depth correctness/security tie, or conflicting `@[…_spec]`
+  tags, yields `ambiguous` (links still resolved). See
+  docs/classification-security-protocol.md.
+-/
+import ProbeLean.Types
+import ProbeLean.Analysis
+import ProbeLean.Classify.Catalogue
+
+namespace ProbeLean.Classify
+
+open Lean ProbeLean
+
+/-- Max reachability-walk depth (cycle/visited-guarded). -/
+def maxWalkDepth : Nat := 16
+
+-- ============================================================
+-- Signal predicates (pure, per-declaration)
+-- ============================================================
+
+private def lower (s : String) : String := s.map Char.toLower
+
+private def hasTag (d : DeclInfo) (t : String) : Bool := d.classAttributes.contains t
+
+private def isStructureKind (d : DeclInfo) : Bool :=
+  match d.kind with | .structure | .class => true | _ => false
+
+private def isTheorem (d : DeclInfo) : Bool :=
+  match d.kind with | .theorem => true | _ => false
+
+/-- Kinds that can realise a scheme (a *construction*): a plain def, an abbrev,
+or an `instance` of a scheme class. -/
+private def isConstructionKind (d : DeclInfo) : Bool :=
+  match d.kind with | .def | .abbrev | .instance => true | _ => false
+
+/-- Kinds that can carry a correctness/security property: theorems and defs.
+Attributes are honoured on these **regardless of codomain shape**, so a
+transformer-stacked game (`StateT σ ProbComp Bool`, shape `other`) tagged
+`@[security_spec]` is still classified. -/
+private def isPropertyTaggable (d : DeclInfo) : Bool :=
+  match d.kind with | .theorem | .def | .abbrev => true | _ => false
+
+/-- A declaration whose codomain *looks* like a property: a theorem, or a `def`
+whose codomain is a predicate / game / advantage. The **naming** signal is gated
+on this (it is heuristic); **attributes** are not (see `isPropertyTaggable`). -/
+private def isPropertyShaped (d : DeclInfo) : Bool :=
+  isTheorem d
+    || d.codomainShape == .prop || d.codomainShape == .game || d.codomainShape == .advantage
+
+/-- A non-theorem property *definition* eligible for stage 3: a def/abbrev that
+is either property-shaped or carries an explicit correctness/security tag. -/
+private def isPropertyDef (d : DeclInfo) : Bool :=
+  !isTheorem d && isPropertyTaggable d
+    && (isPropertyShaped d || hasTag d "correctness_spec" || hasTag d "security_spec")
+
+private def schemeByNaming (d : DeclInfo) : Bool :=
+  isStructureKind d
+    && (d.displayName.endsWith "Scheme" || d.displayName.endsWith "Alg")
+    && !Catalogue.mathlibAlgebraGuard.any (fun g => g.toString == d.displayName)
+
+private def correctnessByNaming (d : DeclInfo) : Bool :=
+  isPropertyShaped d
+    && (containsSubstring (lower d.displayName) "correct"
+        || containsSubstring (lower d.displayName) "complete")
+
+private def securityByNaming (d : DeclInfo) : Bool :=
+  isPropertyShaped d
+    && (containsSubstring (lower d.displayName) "secur"
+        || containsSubstring (lower d.displayName) "advantage"
+        || d.displayName.endsWith "Adv")
+
+-- ============================================================
+-- Classifier state
+-- ============================================================
+
+/-- Working state threaded through the stages. Small project-local sets are
+arrays (a few entries each); `anchors` also seeds the catalogued VCVio anchors. -/
+structure St where
+  result : Array (Name × Classification) := #[]
+  schemes : Array Name := #[]
+  constructions : Array Name := #[]
+  anchors : Array (Name × ClassCategory × ClassVia) := #[]
+  diags : Array String := #[]
+
+namespace St
+
+def isClassified (st : St) (n : Name) : Bool := st.result.any (·.1 == n)
+
+def record (st : St) (n : Name) (c : Classification) : St :=
+  { st with result := st.result.push (n, c) }
+
+def addScheme (st : St) (n : Name) : St := { st with schemes := st.schemes.push n }
+def addConstruction (st : St) (n : Name) : St := { st with constructions := st.constructions.push n }
+
+def promote (st : St) (n : Name) (cat : ClassCategory) (v : ClassVia) : St :=
+  { st with anchors := st.anchors.push (n, cat, v) }
+
+def diag (st : St) (msg : String) : St := { st with diags := st.diags.push msg }
+
+def isScheme (st : St) (n : Name) : Bool := st.schemes.contains n
+def isConstruction (st : St) (n : Name) : Bool := st.constructions.contains n
+
+/-- Look up a classified atom's category (for link resolution). -/
+def categoryOf (st : St) (n : Name) : Option ClassCategory :=
+  (st.result.find? (·.1 == n)).map (·.2.category)
+
+end St
+
+/-- Seed the anchor set with the catalogued VCVio anchors (`via: type`). -/
+private def seedAnchors : Array (Name × ClassCategory × ClassVia) :=
+  Catalogue.correctnessAnchors.map (fun n => (n, ClassCategory.correctness, ClassVia.type))
+    ++ Catalogue.securityAnchors.map (fun n => (n, ClassCategory.security, ClassVia.type))
+
+-- ============================================================
+-- Conflict detection
+-- ============================================================
+
+/-- Both correctness and security tags ⇒ an axis conflict (→ ambiguous). -/
+private def hasAxisConflict (d : DeclInfo) : Bool :=
+  hasTag d "correctness_spec" && hasTag d "security_spec"
+
+/-- A class tag on an incompatible kind (e.g. `@[scheme_def]` on a theorem):
+the tag is ignored and a diagnostic is emitted; the decl falls through to other
+signals. Returns a diagnostic message when such a misuse is present. -/
+private def kindTagMisuse (d : DeclInfo) : Option String :=
+  if hasTag d "scheme_def" && !isStructureKind d then
+    some s!"@[scheme_def] on non-structure '{d.name}' ignored"
+  else if hasTag d "construction_def" && !isConstructionKind d then
+    some s!"@[construction_def] on non-def '{d.name}' ignored"
+  else if (hasTag d "correctness_spec" || hasTag d "security_spec") && !isPropertyTaggable d then
+    some s!"@[…_spec] on non-property '{d.name}' ignored"
+  else none
+
+-- ============================================================
+-- Bounded reachability walk (stages 3B and 4)
+-- ============================================================
+
+/-- A theorem inherits the *weakest* tier in its chain. A structural hop is
+`type`-grade, so a naming-classified anchor drags the verdict to `naming`;
+otherwise it stays `type` (an attribute-pinned anchor upgrades the chain). -/
+private def weakenVia (v : ClassVia) : ClassVia :=
+  match v with | .naming => .naming | _ => .type
+
+inductive WalkResult where
+  | none
+  | decided (cat : ClassCategory) (via : ClassVia)
+  | tie (via : ClassVia)
+  deriving Repr, BEq
+
+/-- Neighbours to expand from `n`: a game-shaped def descends into its body
+(term-deps) as well as its statement (type-deps); everything else follows
+type-deps only. Imported anchors (absent from `declMap`) do not expand. -/
+private def neighbors (declMap : Std.HashMap Name DeclInfo) (n : Name) : Array Name :=
+  match declMap[n]? with
+  | some d =>
+    if d.codomainShape == .game then d.typeDependencies ++ d.termDependencies
+    else d.typeDependencies
+  | none => #[]
+
+private partial def walkBFS (declMap : Std.HashMap Name DeclInfo)
+    (anchorMap : Std.HashMap Name (ClassCategory × ClassVia))
+    (frontier : Array Name) (visited : Std.HashMap Name Unit) (depth : Nat)
+    (cBest sBest : Option (Nat × ClassVia)) : Option (Nat × ClassVia) × Option (Nat × ClassVia) :=
+  if frontier.isEmpty || depth > maxWalkDepth then (cBest, sBest)
+  else
+    -- Record the nearest depth per category. Among anchors at the SAME nearest
+    -- depth, take the weakest `via` (a naming anchor drags the verdict to
+    -- naming), so the result is independent of frontier order.
+    let recordHit (best : Option (Nat × ClassVia)) (v : ClassVia) : Option (Nat × ClassVia) :=
+      match best with
+      | none => some (depth, v)
+      | some (d0, v0) => if d0 == depth && v == .naming then some (d0, .naming) else some (d0, v0)
+    let (cBest, sBest) := frontier.foldl (init := (cBest, sBest)) fun (cb, sb) n =>
+      match anchorMap[n]? with
+      | some (.correctness, v) => (recordHit cb v, sb)
+      | some (.security, v) => (cb, recordHit sb v)
+      | _ => (cb, sb)
+    if cBest.isSome && sBest.isSome then (cBest, sBest)
+    else
+      let (next, visited) := frontier.foldl (init := (#[], visited)) fun (acc, vis) n =>
+        (neighbors declMap n).foldl (init := (acc, vis)) fun (acc, vis) m =>
+          if vis.contains m then (acc, vis) else (acc.push m, vis.insert m ())
+      walkBFS declMap anchorMap next visited (depth + 1) cBest sBest
+
+/-- Classify a declaration by walking its statement to the nearest anchor.
+Strictly-shallower category wins; equal-depth ⇒ `tie`. -/
+private def walk (declMap : Std.HashMap Name DeclInfo)
+    (anchorMap : Std.HashMap Name (ClassCategory × ClassVia)) (d : DeclInfo) : WalkResult :=
+  let roots := neighbors declMap d.name
+  let visited : Std.HashMap Name Unit := roots.foldl (·.insert · ()) {}
+  let (cBest, sBest) := walkBFS declMap anchorMap roots visited 1 none none
+  match cBest, sBest with
+  | none, none => .none
+  | some (_, v), none => .decided .correctness (weakenVia v)
+  | none, some (_, v) => .decided .security (weakenVia v)
+  | some (cd, cv), some (sd, sv) =>
+    if cd < sd then .decided .correctness (weakenVia cv)
+    else if sd < cd then .decided .security (weakenVia sv)
+    else .tie (if cv == .naming || sv == .naming then .naming else .type)
+
+-- ============================================================
+-- Stages
+-- ============================================================
+
+private def baseClass (cat : ClassCategory) (v : ClassVia) : Classification :=
+  { category := cat, «via» := v }
+
+/-- Stage 1 — schemes. -/
+private def stageSchemes (decls : Array DeclInfo) (st : St) : St :=
+  decls.foldl (init := st) fun st d =>
+    let st := match kindTagMisuse d with | some m => st.diag m | none => st
+    if st.isClassified d.name then st
+    else if hasTag d "scheme_def" && isStructureKind d then
+      (st.record d.name (baseClass .scheme .attribute)).addScheme d.name
+    else if schemeByNaming d then
+      (st.record d.name (baseClass .scheme .naming)).addScheme d.name
+    else st
+
+/-- Stage 2 — constructions: a `def`/`abbrev`/`instance` whose return-type head
+is a scheme (project-own or catalogued VCVio), or carrying `@[construction_def]`.
+A def carrying an explicit property tag (`@[correctness_spec]`/`@[security_spec]`)
+is **deferred** to the property stage even if it returns a scheme — attributes are
+authoritative and must not be preempted by construction type-inference. -/
+private def stageConstructions (decls : Array DeclInfo) (st : St) : St :=
+  decls.foldl (init := st) fun st d =>
+    if st.isClassified d.name || !isConstructionKind d
+        || hasTag d "correctness_spec" || hasTag d "security_spec" then st
+    else if hasTag d "construction_def" then
+      (st.record d.name (baseClass .construction .attribute)).addConstruction d.name
+    else
+      match d.codomainHead with
+      | some h =>
+        if st.isScheme h || Catalogue.vcvioSchemeTypes.contains h then
+          (st.record d.name (baseClass .construction .type)).addConstruction d.name
+        else st
+      | none => st
+
+/-- Classify + promote a property declaration to the anchor set. -/
+private def recordProperty (st : St) (d : DeclInfo) (cat : ClassCategory) (v : ClassVia) : St :=
+  (st.record d.name (baseClass cat v)).promote d.name cat v
+
+/-- Stage 3 sub-pass A — attribute and naming signals on property *definitions*
+(non-theorem defs that are property-shaped or tagged), with promotion. -/
+private def stagePropAttrNaming (decls : Array DeclInfo) (st : St) : St :=
+  decls.foldl (init := st) fun st d =>
+    if st.isClassified d.name || !isPropertyDef d then st
+    else if hasAxisConflict d then
+      (st.record d.name (baseClass .ambiguous .attribute)).diag
+        s!"conflicting @[correctness_spec]+@[security_spec] on '{d.name}'"
+    else if hasTag d "correctness_spec" then recordProperty st d .correctness .attribute
+    else if hasTag d "security_spec" then recordProperty st d .security .attribute
+    else if correctnessByNaming d && securityByNaming d then
+      st.record d.name (baseClass .ambiguous .naming)
+    else if correctnessByNaming d then recordProperty st d .correctness .naming
+    else if securityByNaming d then recordProperty st d .security .naming
+    else st
+
+/-- Stage 3 sub-pass B — one type-reach pass over remaining property defs.
+Returns the updated state and whether anything new was classified. -/
+private def stagePropReachPass (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo)
+    (st : St) : St × Bool :=
+  -- Snapshot the anchor set ONCE: every def in this pass is evaluated against
+  -- the same set, and defs promoted during the pass become visible only in the
+  -- NEXT pass. This makes the within-pass order irrelevant — the fixed point is
+  -- order-independent (the anchor set grows monotonically across passes).
+  let anchorMap : Std.HashMap Name (ClassCategory × ClassVia) :=
+    st.anchors.foldl (fun m e => m.insert e.1 (e.2.1, e.2.2)) {}
+  decls.foldl (init := (st, false)) fun (st, changed) d =>
+    if st.isClassified d.name || isTheorem d || !isPropertyTaggable d || !isPropertyShaped d then (st, changed)
+    else
+      match walk declMap anchorMap d with
+      | .none => (st, changed)
+      | .tie v => (st.record d.name (baseClass .ambiguous v), true)
+      | .decided cat v => (recordProperty st d cat v, true)
+
+/-- Iterate sub-pass B to a fixed point (anchor set only grows; order-independent). -/
+private partial def stagePropReachLoop (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo)
+    (st : St) : St :=
+  let (st, changed) := stagePropReachPass declMap decls st
+  if changed then stagePropReachLoop declMap decls st else st
+
+/-- Stage 4 — theorems: attribute, then walk, then naming. The anchor set is
+frozen by now (theorems never promote), so the anchor map is built once. -/
+private def stageTheorems (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo) (st : St) : St :=
+  let anchorMap : Std.HashMap Name (ClassCategory × ClassVia) :=
+    st.anchors.foldl (fun m e => m.insert e.1 (e.2.1, e.2.2)) {}
+  decls.foldl (init := st) fun st d =>
+    if st.isClassified d.name || !isTheorem d then st
+    else if hasAxisConflict d then
+      (st.record d.name (baseClass .ambiguous .attribute)).diag
+        s!"conflicting @[correctness_spec]+@[security_spec] on '{d.name}'"
+    else if hasTag d "correctness_spec" then st.record d.name (baseClass .correctness .attribute)
+    else if hasTag d "security_spec" then st.record d.name (baseClass .security .attribute)
+    else
+      match walk declMap anchorMap d with
+      | .decided cat v => st.record d.name (baseClass cat v)
+      | .tie v => st.record d.name (baseClass .ambiguous v)
+      | .none =>
+        if correctnessByNaming d && securityByNaming d then
+          st.record d.name (baseClass .ambiguous .naming)
+        else if correctnessByNaming d then st.record d.name (baseClass .correctness .naming)
+        else if securityByNaming d then st.record d.name (baseClass .security .naming)
+        else st
+
+-- ============================================================
+-- Link resolution (fail-closed)
+-- ============================================================
+
+/-- The unique members of `cands` that are classified atoms of `kind`, as a
+sorted-deduped array (`[]` = none, one = string link, many = ambiguous array). -/
+private def uniqueClassified (cands : Array Name) (pred : Name → Bool) : Array Name :=
+  let hits := cands.filter pred
+  (hits.foldl (init := #[]) fun acc n => if acc.contains n then acc else acc.push n)
+    |>.qsort (·.toString < ·.toString)
+
+private def schemeOfConstruction (st : St) (construction : Name) : Array Name :=
+  match st.result.find? (·.1 == construction) with
+  | some (_, c) => c.scheme
+  | none => #[]
+
+/-- Resolve `scheme`/`construction` links for every classified atom. Two passes:
+constructions first (so properties can read their scheme), then properties. -/
+private def resolveLinks (decls : Array DeclInfo) (emitted : Array Name) (st : St) : St :=
+  let declOf (n : Name) : Option DeclInfo := decls.find? (·.name == n)
+  -- pass 1: constructions → scheme = return-type head iff a classified, emitted scheme atom
+  let st := st.result.foldl (init := { st with result := #[] }) fun st (n, c) =>
+    match c.category with
+    | .construction =>
+      let scheme := match declOf n |>.bind (·.codomainHead) with
+        | some h => if st.isScheme h && emitted.contains h then #[h] else #[]
+        | none => #[]
+      st.record n { c with scheme }
+    | _ => st.record n c
+  -- pass 2: correctness/security/ambiguous → construction (unique) + scheme
+  let st := st.result.foldl (init := { st with result := #[] }) fun st (n, c) =>
+    match c.category with
+    | .correctness | .security | .ambiguous =>
+      let typeDeps := (declOf n).map (·.typeDependencies) |>.getD #[]
+      let constructions := uniqueClassified typeDeps
+        (fun m => st.isConstruction m && emitted.contains m)
+      let scheme :=
+        if constructions.isEmpty then
+          uniqueClassified typeDeps (fun m => st.isScheme m && emitted.contains m)
+        else
+          (constructions.foldl (init := #[]) fun acc cn =>
+            (schemeOfConstruction st cn).foldl (init := acc) fun acc s =>
+              if acc.contains s then acc else acc.push s).qsort (·.toString < ·.toString)
+      st.record n { c with construction := constructions, scheme }
+    | _ => st.record n c
+  st
+
+-- ============================================================
+-- Entry point
+-- ============================================================
+
+/-- Classify all project declarations. Returns `(name, classification)` pairs
+for the classified atoms (unclassified atoms are simply absent) and a list of
+diagnostics (tag conflicts/misuse). Pure. -/
+def classify (decls : Array DeclInfo) : Array (Name × Classification) × Array String :=
+  let declMap : Std.HashMap Name DeclInfo := decls.foldl (fun m d => m.insert d.name d) {}
+  let emitted := decls.map (·.name)
+  let st0 : St := { anchors := seedAnchors }
+  let st := stageSchemes decls st0
+  let st := stageConstructions decls st
+  let st := stagePropAttrNaming decls st
+  let st := stagePropReachLoop declMap decls st
+  let st := stageTheorems declMap decls st
+  let st := resolveLinks decls emitted st
+  (st.result, st.diags)
+
+end ProbeLean.Classify

--- a/ProbeLean/Classify/SecurityProtocol.lean
+++ b/ProbeLean/Classify/SecurityProtocol.lean
@@ -94,7 +94,7 @@ structure St where
   result : Array (Name × Classification) := #[]
   schemes : Array Name := #[]
   constructions : Array Name := #[]
-  anchors : Array (Name × ClassCategory × ClassVia) := #[]
+  anchors : Array (Name × SecurityProtocolCategory × ClassVia) := #[]
   diags : Array String := #[]
 
 namespace St
@@ -107,7 +107,7 @@ def record (st : St) (n : Name) (c : Classification) : St :=
 def addScheme (st : St) (n : Name) : St := { st with schemes := st.schemes.push n }
 def addConstruction (st : St) (n : Name) : St := { st with constructions := st.constructions.push n }
 
-def promote (st : St) (n : Name) (cat : ClassCategory) (v : ClassVia) : St :=
+def promote (st : St) (n : Name) (cat : SecurityProtocolCategory) (v : ClassVia) : St :=
   { st with anchors := st.anchors.push (n, cat, v) }
 
 def diag (st : St) (msg : String) : St := { st with diags := st.diags.push msg }
@@ -116,15 +116,15 @@ def isScheme (st : St) (n : Name) : Bool := st.schemes.contains n
 def isConstruction (st : St) (n : Name) : Bool := st.constructions.contains n
 
 /-- Look up a classified atom's category (for link resolution). -/
-def categoryOf (st : St) (n : Name) : Option ClassCategory :=
+def categoryOf (st : St) (n : Name) : Option SecurityProtocolCategory :=
   (st.result.find? (·.1 == n)).map (·.2.category)
 
 end St
 
 /-- Seed the anchor set with the catalogued VCVio anchors (`via: type`). -/
-private def seedAnchors : Array (Name × ClassCategory × ClassVia) :=
-  Catalogue.correctnessAnchors.map (fun n => (n, ClassCategory.correctness, ClassVia.type))
-    ++ Catalogue.securityAnchors.map (fun n => (n, ClassCategory.security, ClassVia.type))
+private def seedAnchors : Array (Name × SecurityProtocolCategory × ClassVia) :=
+  Catalogue.correctnessAnchors.map (fun n => (n, SecurityProtocolCategory.correctness, ClassVia.type))
+    ++ Catalogue.securityAnchors.map (fun n => (n, SecurityProtocolCategory.security, ClassVia.type))
 
 -- ============================================================
 -- Conflict detection
@@ -158,7 +158,7 @@ private def weakenVia (v : ClassVia) : ClassVia :=
 
 inductive WalkResult where
   | none
-  | decided (cat : ClassCategory) (via : ClassVia)
+  | decided (cat : SecurityProtocolCategory) (via : ClassVia)
   | tie (via : ClassVia)
   deriving Repr, BEq
 
@@ -173,7 +173,7 @@ private def neighbors (declMap : Std.HashMap Name DeclInfo) (n : Name) : Array N
   | none => #[]
 
 private partial def walkBFS (declMap : Std.HashMap Name DeclInfo)
-    (anchorMap : Std.HashMap Name (ClassCategory × ClassVia))
+    (anchorMap : Std.HashMap Name (SecurityProtocolCategory × ClassVia))
     (frontier : Array Name) (visited : Std.HashMap Name Unit) (depth : Nat)
     (cBest sBest : Option (Nat × ClassVia)) : Option (Nat × ClassVia) × Option (Nat × ClassVia) :=
   if frontier.isEmpty || depth > maxWalkDepth then (cBest, sBest)
@@ -200,7 +200,7 @@ private partial def walkBFS (declMap : Std.HashMap Name DeclInfo)
 /-- Classify a declaration by walking its statement to the nearest anchor.
 Strictly-shallower category wins; equal-depth ⇒ `tie`. -/
 private def walk (declMap : Std.HashMap Name DeclInfo)
-    (anchorMap : Std.HashMap Name (ClassCategory × ClassVia)) (d : DeclInfo) : WalkResult :=
+    (anchorMap : Std.HashMap Name (SecurityProtocolCategory × ClassVia)) (d : DeclInfo) : WalkResult :=
   let roots := neighbors declMap d.name
   let visited : Std.HashMap Name Unit := roots.foldl (·.insert · ()) {}
   let (cBest, sBest) := walkBFS declMap anchorMap roots visited 1 none none
@@ -217,7 +217,7 @@ private def walk (declMap : Std.HashMap Name DeclInfo)
 -- Stages
 -- ============================================================
 
-private def baseClass (cat : ClassCategory) (v : ClassVia) : Classification :=
+private def baseClass (cat : SecurityProtocolCategory) (v : ClassVia) : Classification :=
   { category := cat, «via» := v }
 
 /-- Stage 1 — schemes. -/
@@ -251,7 +251,7 @@ private def stageConstructions (decls : Array DeclInfo) (st : St) : St :=
       | none => st
 
 /-- Classify + promote a property declaration to the anchor set. -/
-private def recordProperty (st : St) (d : DeclInfo) (cat : ClassCategory) (v : ClassVia) : St :=
+private def recordProperty (st : St) (d : DeclInfo) (cat : SecurityProtocolCategory) (v : ClassVia) : St :=
   (st.record d.name (baseClass cat v)).promote d.name cat v
 
 /-- Stage 3 sub-pass A — attribute and naming signals on property *definitions*
@@ -270,34 +270,60 @@ private def stagePropAttrNaming (decls : Array DeclInfo) (st : St) : St :=
     else if securityByNaming d then recordProperty st d .security .naming
     else st
 
-/-- Stage 3 sub-pass B — one type-reach pass over remaining property defs.
-Returns the updated state and whether anything new was classified. -/
-private def stagePropReachPass (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo)
-    (st : St) : St × Bool :=
+/-- Stage 3 sub-pass B — one type-reach pass over the candidate property defs in
+`work`. Returns `(state, remaining, anchorAdded)`: `remaining` are the candidates
+that reached no anchor this pass (to retry next pass); `anchorAdded` is whether a
+*new anchor* was promoted (a `.decided` result) — NOT merely whether something was
+recorded. A `.tie` records `ambiguous` but promotes no anchor, so it cannot unblock
+any remaining candidate; only a new anchor can. Tracking anchor additions (rather
+than any record) lets the fixpoint stop one pass sooner without changing the result.
+
+This refactor is **behavior-preserving** relative to the previous loop, not a
+re-derivation of ideal nearest-anchor semantics: like before, an unresolved def is
+re-walked against a later (larger) anchor set, but a def that already reached a
+verdict — including a `.tie` → `ambiguous` — keeps that verdict (the old loop
+skipped it via `isClassified`; here it is simply not carried forward). A later
+anchor that would have been *nearer* does not retroactively revise an earlier
+verdict; that is a pre-existing property of the staged classifier, unchanged here. -/
+private def stagePropReachPass (declMap : Std.HashMap Name DeclInfo) (work : Array DeclInfo)
+    (st : St) : St × Array DeclInfo × Bool :=
   -- Snapshot the anchor set ONCE: every def in this pass is evaluated against
   -- the same set, and defs promoted during the pass become visible only in the
   -- NEXT pass. This makes the within-pass order irrelevant — the fixed point is
   -- order-independent (the anchor set grows monotonically across passes).
-  let anchorMap : Std.HashMap Name (ClassCategory × ClassVia) :=
+  let anchorMap : Std.HashMap Name (SecurityProtocolCategory × ClassVia) :=
     st.anchors.foldl (fun m e => m.insert e.1 (e.2.1, e.2.2)) {}
-  decls.foldl (init := (st, false)) fun (st, changed) d =>
-    if st.isClassified d.name || isTheorem d || !isPropertyTaggable d || !isPropertyShaped d then (st, changed)
+  work.foldl (init := (st, #[], false)) fun (st, rem, anchorAdded) d =>
+    if st.isClassified d.name then (st, rem, anchorAdded)   -- e.g. classified by sub-pass A
     else
       match walk declMap anchorMap d with
-      | .none => (st, changed)
-      | .tie v => (st.record d.name (baseClass .ambiguous v), true)
-      | .decided cat v => (recordProperty st d cat v, true)
+      | .none => (st, rem.push d, anchorAdded)               -- no anchor yet → retry next pass
+      | .tie v => (st.record d.name (baseClass .ambiguous v), rem, anchorAdded)  -- no new anchor
+      | .decided cat v => (recordProperty st d cat v, rem, true)
 
-/-- Iterate sub-pass B to a fixed point (anchor set only grows; order-independent). -/
-private partial def stagePropReachLoop (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo)
+/-- Iterate sub-pass B to a fixed point. The candidate set is filtered **once**
+and only the still-unresolved defs are carried forward, so each pass re-walks
+just what is left (not all decls). We recurse only when a *new anchor* was added
+**and** unresolved candidates remain: a pass that produced only ties (or nothing)
+left the anchor set unchanged, so another pass over `rem` would walk the identical
+anchor map and find nothing new. The per-pass anchor snapshot — and thus
+order-independence — is unchanged. -/
+private partial def reachFixpoint (declMap : Std.HashMap Name DeclInfo) (work : Array DeclInfo)
     (st : St) : St :=
-  let (st, changed) := stagePropReachPass declMap decls st
-  if changed then stagePropReachLoop declMap decls st else st
+  let (st, rem, anchorAdded) := stagePropReachPass declMap work st
+  if anchorAdded && !rem.isEmpty then reachFixpoint declMap rem st else st
+
+private def stagePropReachLoop (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo)
+    (st : St) : St :=
+  -- Filter mirrors the old per-pass guard exactly; sub-pass-A-classified defs
+  -- fall out on pass 1 via the `isClassified` check in `stagePropReachPass`.
+  let work := decls.filter fun d => !isTheorem d && isPropertyTaggable d && isPropertyShaped d
+  reachFixpoint declMap work st
 
 /-- Stage 4 — theorems: attribute, then walk, then naming. The anchor set is
 frozen by now (theorems never promote), so the anchor map is built once. -/
 private def stageTheorems (declMap : Std.HashMap Name DeclInfo) (decls : Array DeclInfo) (st : St) : St :=
-  let anchorMap : Std.HashMap Name (ClassCategory × ClassVia) :=
+  let anchorMap : Std.HashMap Name (SecurityProtocolCategory × ClassVia) :=
     st.anchors.foldl (fun m e => m.insert e.1 (e.2.1, e.2.2)) {}
   decls.foldl (init := st) fun st d =>
     if st.isClassified d.name || !isTheorem d then st

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -24,6 +24,7 @@ structure ExtractConfig where
   fromFile : Option System.FilePath
   libraries : Option (Array String) := none
   skipEnrich : Bool := false
+  classOverride : Option String := none
   deriving Repr
 
 /-- Map probe-lean VerifyStatus to the web frontend's verification status -/
@@ -194,11 +195,11 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   let userConfig ← loadUserConfig config.projectPath
   let crate := loadRelevantCrate userConfig
 
-  let atoms ← match ← runAnalysisViaLakeEnv config.projectPath filteredModules crate nixMode with
+  let (atoms, projectClass) ← match ← runAnalysisViaLakeEnv config.projectPath filteredModules crate nixMode config.classOverride with
     | .error msg =>
       IO.eprintln s!"Analysis failed: {msg}"
       return 1
-    | .ok atoms => pure atoms
+    | .ok result => pure result
 
   IO.println s!"Found {atoms.size} atoms"
 
@@ -253,7 +254,8 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
     IO.println s!"Transitively verified: {transitive} | Locally verified: {local_} | Not verified: {notVerified}"
     pure enriched
 
-  let source ← collectSourceInfo config.projectPath
+  let baseSource ← collectSourceInfo config.projectPath
+  let source := { baseSource with sourceClass := projectClass }
   let timestamp ← getCurrentTimestamp
 
   let output : UnifiedAtomsOutput := { atoms := unifiedAtoms }

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -55,6 +55,7 @@ def isTrustedAtom (atom : Atom) : Bool :=
     `@[externally_verified]`, and non-theorem declarations from `*External.lean`
     files are overridden to `trusted` regardless of sorry detection. -/
 def unifyAtom (atom : Atom) (proofEntry : Option ProofEntry)
+    (classification : Option Classification := none)
     : UnifiedAtom :=
   let baseStatus := proofEntry.map fun p => mapVerifyStatus p.status
   let reason := trustedReason atom
@@ -82,7 +83,15 @@ def unifyAtom (atom : Atom) (proofEntry : Option ProofEntry)
     primarySpec := atom.primarySpec
     verificationStatus := status
     trustedReason := reason
+    classification := classification
   }
+
+/-- Index per-declaration classifications by the emitted atom's `probe:`-prefixed
+    code-name, so the merge can attach each atom's classification in O(1). The
+    classifier keys by raw `Name`; atoms are keyed by `addProbePrefix name.toString`
+    (the same expression `declInfoToAtom` uses), so the two sides line up. -/
+def buildClassMap (classifications : Array (Name × Classification)) : Std.HashMap String Classification :=
+  classifications.foldl (fun m (n, c) => m.insert (addProbePrefix n.toString) c) {}
 
 /-- Check whether a module belongs to one of the given library roots.
     A module `A.B.C` belongs to library `A` if its name equals `A` or starts with `A.`. -/
@@ -195,11 +204,13 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   let userConfig ← loadUserConfig config.projectPath
   let crate := loadRelevantCrate userConfig
 
-  let (atoms, projectClass) ← match ← runAnalysisViaLakeEnv config.projectPath filteredModules crate nixMode config.classOverride with
+  let (atoms, projectClass, classifications) ← match ← runAnalysisViaLakeEnv config.projectPath filteredModules crate nixMode config.classOverride with
     | .error msg =>
       IO.eprintln s!"Analysis failed: {msg}"
       return 1
     | .ok result => pure result
+
+  let classMap := buildClassMap classifications
 
   IO.println s!"Found {atoms.size} atoms"
 
@@ -239,7 +250,7 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
 
   let unifiedAtoms := atoms.mapIdx fun i atom =>
     let proof := proofEntries.bind fun ps => ps[i]?
-    unifyAtom atom proof
+    unifyAtom atom proof classMap[atom.name]?
 
   -- === Enrich: transitive verification via reverse-BFS ===
   let unifiedAtoms ← if config.skipEnrich then

--- a/ProbeLean/Main.lean
+++ b/ProbeLean/Main.lean
@@ -31,6 +31,9 @@ def runExtract (parsed : Parsed) : IO UInt32 := do
   let libraries := parsed.flag? "library" |>.map fun f =>
     (f.as! String).splitOn "," |>.map (fun s => s.trimAscii.toString) |>.toArray
   let skipEnrich := parsed.hasFlag "skip-enrich"
+  let classOverride := (parsed.flag? "class" |>.map (·.as! String)).bind fun s =>
+    let t := s.trimAscii.toString
+    if t.isEmpty then none else some t
 
   let config : ExtractConfig := {
     projectPath := projectPath
@@ -40,6 +43,7 @@ def runExtract (parsed : Parsed) : IO UInt32 := do
     fromFile := fromFile
     libraries := libraries
     skipEnrich := skipEnrich
+    classOverride := classOverride
   }
 
   runExtractInProject config
@@ -56,6 +60,7 @@ def extractCmd : Cmd := `[Cli|
     "from-file" : String; "Use existing build output for sorry detection instead of running lake"
     l, library : String; "Comma-separated list of library names to build (default: auto-detect from lakefile.toml)"
     "skip-enrich"; "Skip transitive verification enrichment"
+    "class" : String; "Override the detected project class (e.g. security-protocol)"
 
   ARGS:
     projectPath : String; "Path to the Lean 4 project to analyze"

--- a/ProbeLean/Types.lean
+++ b/ProbeLean/Types.lean
@@ -211,7 +211,7 @@ crypto *property* whose correctness-vs-security axis could not be decided (an
 equal-depth reachability tie, or conflicting `@[…_spec]` tags). It still carries
 `scheme`/`construction` links, so it is placeable but flagged to resolve with a
 tag — distinct from an absent classification (not a property at all). -/
-inductive ClassCategory where
+inductive SecurityProtocolCategory where
   | scheme
   | construction
   | correctness
@@ -219,7 +219,7 @@ inductive ClassCategory where
   | ambiguous
   deriving Repr, BEq
 
-instance : Lean.ToJson ClassCategory where
+instance : Lean.ToJson SecurityProtocolCategory where
   toJson
     | .scheme => "scheme"
     | .construction => "construction"
@@ -227,7 +227,7 @@ instance : Lean.ToJson ClassCategory where
     | .security => "security"
     | .ambiguous => "ambiguous"
 
-instance : Lean.FromJson ClassCategory where
+instance : Lean.FromJson SecurityProtocolCategory where
   fromJson? json := do
     let s ← json.getStr?
     match s with
@@ -236,7 +236,7 @@ instance : Lean.FromJson ClassCategory where
     | "correctness" => return .correctness
     | "security" => return .security
     | "ambiguous" => return .ambiguous
-    | _ => throw s!"Unknown ClassCategory: {s}"
+    | _ => throw s!"Unknown SecurityProtocolCategory: {s}"
 
 /-- How a classification was determined — the weakest signal in the chain. -/
 inductive ClassVia where
@@ -266,7 +266,7 @@ name serialises as a `probe:`-prefixed string; multiple names (genuinely
 ambiguous) serialise as an array of such strings. Field order matches the
 serialised JSON (`construction` before `scheme`) per the design doc example. -/
 structure Classification where
-  category : ClassCategory
+  category : SecurityProtocolCategory
   «via» : ClassVia
   construction : Array Lean.Name := #[]
   scheme : Array Lean.Name := #[]
@@ -321,7 +321,7 @@ instance : Lean.ToJson Classification where
 
 instance : Lean.FromJson Classification where
   fromJson? json := do
-    let category ← json.getObjValAs? ClassCategory "category"
+    let category ← json.getObjValAs? SecurityProtocolCategory "category"
     let «via» ← json.getObjValAs? ClassVia "via"
     let construction ← classLinkFromJson json "construction"
     let scheme ← classLinkFromJson json "scheme"

--- a/ProbeLean/Types.lean
+++ b/ProbeLean/Types.lean
@@ -58,16 +58,24 @@ structure SourceInfo where
   language : String := "lean"
   package : String
   packageVersion : String
+  /-- Detected project class (e.g. `"security-protocol"`). Serialised to the
+      JSON key `class`; omitted when no class is detected. -/
+  sourceClass : Option String := none
   deriving Repr, BEq
 
 instance : Lean.ToJson SourceInfo where
-  toJson info := Lean.Json.mkObj [
-    ("repo", Lean.toJson info.repo),
-    ("commit", Lean.toJson info.commit),
-    ("language", Lean.toJson info.language),
-    ("package", Lean.toJson info.package),
-    ("package-version", Lean.toJson info.packageVersion)
-  ]
+  toJson info :=
+    let base := [
+      ("repo", Lean.toJson info.repo),
+      ("commit", Lean.toJson info.commit),
+      ("language", Lean.toJson info.language),
+      ("package", Lean.toJson info.package),
+      ("package-version", Lean.toJson info.packageVersion)
+    ]
+    let withClass := match info.sourceClass with
+      | some c => base ++ [("class", Lean.toJson c)]
+      | none => base
+    Lean.Json.mkObj withClass
 
 instance : Lean.FromJson SourceInfo where
   fromJson? json := do
@@ -76,7 +84,8 @@ instance : Lean.FromJson SourceInfo where
     let language ← json.getObjValAs? String "language" <|> pure "lean"
     let package ← json.getObjValAs? String "package"
     let packageVersion ← json.getObjValAs? String "package-version"
-    return { repo, commit, language, package, packageVersion }
+    let sourceClass ← json.getObjValAs? (Option String) "class" <|> pure none
+    return { repo, commit, language, package, packageVersion, sourceClass }
 
 /-- Typed envelope wrapper for all Schema 2.0 outputs -/
 structure Envelope (α : Type) where
@@ -190,6 +199,133 @@ instance : Lean.FromJson DeclKind where
 
 instance : Inhabited DeclKind where
   default := .def
+
+-- ============================================================
+-- Security-protocol classification
+-- (see docs/classification-security-protocol.md)
+-- ============================================================
+
+/-- The security-protocol categories an atom can be classified into. The first
+four are the hierarchy leaves; `ambiguous` marks a declaration recognised as a
+crypto *property* whose correctness-vs-security axis could not be decided (an
+equal-depth reachability tie, or conflicting `@[…_spec]` tags). It still carries
+`scheme`/`construction` links, so it is placeable but flagged to resolve with a
+tag — distinct from an absent classification (not a property at all). -/
+inductive ClassCategory where
+  | scheme
+  | construction
+  | correctness
+  | security
+  | ambiguous
+  deriving Repr, BEq
+
+instance : Lean.ToJson ClassCategory where
+  toJson
+    | .scheme => "scheme"
+    | .construction => "construction"
+    | .correctness => "correctness"
+    | .security => "security"
+    | .ambiguous => "ambiguous"
+
+instance : Lean.FromJson ClassCategory where
+  fromJson? json := do
+    let s ← json.getStr?
+    match s with
+    | "scheme" => return .scheme
+    | "construction" => return .construction
+    | "correctness" => return .correctness
+    | "security" => return .security
+    | "ambiguous" => return .ambiguous
+    | _ => throw s!"Unknown ClassCategory: {s}"
+
+/-- How a classification was determined — the weakest signal in the chain. -/
+inductive ClassVia where
+  | attribute
+  | type
+  | naming
+  deriving Repr, BEq
+
+instance : Lean.ToJson ClassVia where
+  toJson
+    | .attribute => "attribute"
+    | .type => "type"
+    | .naming => "naming"
+
+instance : Lean.FromJson ClassVia where
+  fromJson? json := do
+    let s ← json.getStr?
+    match s with
+    | "attribute" => return .attribute
+    | "type" => return .type
+    | "naming" => return .naming
+    | _ => throw s!"Unknown ClassVia: {s}"
+
+/-- A classification annotation on an atom. `scheme`/`construction` are the
+explicit hierarchy links: empty means absent (unresolvable / orphan); a single
+name serialises as a `probe:`-prefixed string; multiple names (genuinely
+ambiguous) serialise as an array of such strings. Field order matches the
+serialised JSON (`construction` before `scheme`) per the design doc example. -/
+structure Classification where
+  category : ClassCategory
+  «via» : ClassVia
+  construction : Array Lean.Name := #[]
+  scheme : Array Lean.Name := #[]
+  deriving Repr, BEq
+
+/-- Deduplicate and stably sort a link's names so serialised output is
+deterministic regardless of how the classifier produced them (P14). -/
+def normalizeClassLink (names : Array Lean.Name) : Array Lean.Name :=
+  let sorted := names.qsort (fun a b => a.toString < b.toString)
+  sorted.foldl (init := #[]) fun acc n =>
+    if acc.contains n then acc else acc.push n
+
+/-- Serialise a link field: omitted when empty, a `probe:`-prefixed string when
+singular, an array of such strings when ambiguous. Names are normalised first. -/
+def classLinkToJson (names : Array Lean.Name) : Option Lean.Json :=
+  match normalizeClassLink names with
+  | #[] => none
+  | #[n] => some (Lean.toJson (addProbePrefix n.toString))
+  | ns => some (Lean.toJson (ns.map fun n => addProbePrefix n.toString))
+
+/-- Parse a link field that may be absent, a single string, or an array of
+strings. Absent → empty. A present value that is not a string or an array of
+strings is a hard error (fail loud on a malformed producer), per the
+`string | array<string>` contract. The `probe:` prefix is stripped. -/
+def classLinkFromJson (json : Lean.Json) (key : String) : Except String (Array Lean.Name) :=
+  match json.getObjVal? key with
+  | .error _ => .ok #[]  -- absent: a normal, unresolved link
+  | .ok v =>
+    match v.getStr? with
+    | .ok s => .ok #[(stripProbePrefix s).toName]
+    | .error _ =>
+      match v.getArr? with
+      | .ok arr => arr.foldlM (init := #[]) fun acc e =>
+          match e.getStr? with
+          | .ok s => .ok (acc.push (stripProbePrefix s).toName)
+          | .error _ => .error s!"classification link '{key}' array element is not a string"
+      | .error _ => .error s!"classification link '{key}' must be a string or array of strings"
+
+instance : Lean.ToJson Classification where
+  toJson c :=
+    let base := [
+      ("category", Lean.toJson c.category),
+      ("via", Lean.toJson c.via)
+    ]
+    let withConstruction := match classLinkToJson c.construction with
+      | some j => base ++ [("construction", j)]
+      | none => base
+    let withScheme := match classLinkToJson c.scheme with
+      | some j => withConstruction ++ [("scheme", j)]
+      | none => withConstruction
+    Lean.Json.mkObj withScheme
+
+instance : Lean.FromJson Classification where
+  fromJson? json := do
+    let category ← json.getObjValAs? ClassCategory "category"
+    let «via» ← json.getObjValAs? ClassVia "via"
+    let construction ← classLinkFromJson json "construction"
+    let scheme ← classLinkFromJson json "scheme"
+    return { category, «via», construction, scheme }
 
 /-- An atom representing a declaration in the dependency graph -/
 structure Atom where
@@ -431,6 +567,7 @@ structure UnifiedAtom where
   primarySpec : Option String := none
   verificationStatus : Option WebVerificationStatus
   trustedReason : Option String := none
+  classification : Option Classification := none
   deriving Repr, BEq, Inhabited
 
 instance : Lean.ToJson UnifiedAtom where
@@ -465,7 +602,10 @@ instance : Lean.ToJson UnifiedAtom where
     let withTrustedReason := match atom.trustedReason with
       | some reason => withVerification ++ [("trusted-reason", Lean.toJson reason)]
       | none => withVerification
-    Lean.Json.mkObj withTrustedReason
+    let withClassification := match atom.classification with
+      | some c => withTrustedReason ++ [("classification", Lean.toJson c)]
+      | none => withTrustedReason
+    Lean.Json.mkObj withClassification
 
 instance : Lean.FromJson UnifiedAtom where
   fromJson? json := do
@@ -491,7 +631,8 @@ instance : Lean.FromJson UnifiedAtom where
     let primarySpec ← json.getObjValAs? (Option String) "primary-spec" <|> pure none
     let verificationStatus ← json.getObjValAs? (Option WebVerificationStatus) "verification-status" <|> pure none
     let trustedReason ← json.getObjValAs? (Option String) "trusted-reason" <|> pure none
-    return { name, displayName, dependencies, typeDependencies, termDependencies, codeModule, codePath, codeText, kind, language, isHidden, isExtractionArtifact, isIgnored, isRelevant, isInPackage, rustSource, attributes, specs, isPrimarySpec, primarySpec, verificationStatus, trustedReason }
+    let classification ← json.getObjValAs? (Option Classification) "classification" <|> pure none
+    return { name, displayName, dependencies, typeDependencies, termDependencies, codeModule, codePath, codeText, kind, language, isHidden, isExtractionArtifact, isIgnored, isRelevant, isInPackage, rustSource, attributes, specs, isPrimarySpec, primarySpec, verificationStatus, trustedReason, classification }
 
 /-- Output format for unified atoms - an object keyed by atom name -/
 structure UnifiedAtomsOutput where

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.7.0"
+def version : String := "0.8.0"
 
 end ProbeLean

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 | `--skip-verify` | Skip sorry detection (graph structure only) |
 | `--from-file <FILE>` | Use existing build output for sorry detection |
 | `--skip-enrich` | Skip transitive verification enrichment (no `"transitively-verified"` status) |
+| `--class <NAME>` | Override the detected project class (e.g. `security-protocol`) |
+
+### Security-protocol classification
+
+For VCVio-based cryptographic projects, `extract` additionally classifies declarations into a
+`scheme → construction → {correctness, security}` hierarchy — emitting `source.class` and a per-atom
+`classification` object so a consumer can render an accordion. The class is auto-detected from a
+VCVio dependency; schemes not named `*Scheme`/`*Alg` should carry `@[scheme_def]` (from
+`ProbeLean.Attrs`). See **[docs/classification-security-protocol.md](docs/classification-security-protocol.md)**.
 
 For the full command reference with examples, see **[docs/USAGE.md](docs/USAGE.md)**. For the complete JSON schema specification, see **[docs/SCHEMA.md](docs/SCHEMA.md)**.
 
@@ -131,7 +140,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 {
   "schema": "probe-lean/extract",
   "schema-version": "2.0",
-  "tool": { "name": "probe-lean", "version": "0.7.0", "command": "extract" },
+  "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
     "commit": "abc123d",

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -800,18 +800,18 @@ run_cmd do
 def testClassificationJson (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
-  IO.println "Testing ClassCategory / ClassVia round-trips..."
-  let catRt := match Lean.FromJson.fromJson? (Lean.toJson ClassCategory.construction) (α := ClassCategory) with
+  IO.println "Testing SecurityProtocolCategory / ClassVia round-trips..."
+  let catRt := match Lean.FromJson.fromJson? (Lean.toJson SecurityProtocolCategory.construction) (α := SecurityProtocolCategory) with
     | .ok .construction => true | _ => false
-  let ambRt := match Lean.FromJson.fromJson? (Lean.toJson ClassCategory.ambiguous) (α := ClassCategory) with
+  let ambRt := match Lean.FromJson.fromJson? (Lean.toJson SecurityProtocolCategory.ambiguous) (α := SecurityProtocolCategory) with
     | .ok .ambiguous => true | _ => false
   let viaRt := match Lean.FromJson.fromJson? (Lean.toJson ClassVia.naming) (α := ClassVia) with
     | .ok .naming => true | _ => false
-  result ← test "ClassCategory round-trips" catRt result
-  result ← test "ClassCategory ambiguous round-trips" ambRt result
+  result ← test "SecurityProtocolCategory round-trips" catRt result
+  result ← test "SecurityProtocolCategory ambiguous round-trips" ambRt result
   result ← test "ClassVia round-trips" viaRt result
-  result ← test "ClassCategory scheme toJson" (Lean.toJson ClassCategory.scheme == "scheme") result
-  result ← test "ClassCategory ambiguous toJson" (Lean.toJson ClassCategory.ambiguous == "ambiguous") result
+  result ← test "SecurityProtocolCategory scheme toJson" (Lean.toJson SecurityProtocolCategory.scheme == "scheme") result
+  result ← test "SecurityProtocolCategory ambiguous toJson" (Lean.toJson SecurityProtocolCategory.ambiguous == "ambiguous") result
   result ← test "ClassVia attribute toJson" (Lean.toJson ClassVia.attribute == "attribute") result
 
   IO.println ""
@@ -1005,6 +1005,32 @@ def testDetectClass (result : TestResult) : IO TestResult := do
     (!moduleListIndicatesSecurityProtocol #[`VCVioExtra]) result
   result ← test "empty module list → not detected"
     (!moduleListIndicatesSecurityProtocol #[]) result
+
+  IO.println ""
+  IO.println "Testing manifest detection (direct VCVio dep only)..."
+  let directVCVio := "{\"packages\": [{\"name\": \"VCVio\", \"inherited\": false}, {\"name\": \"mathlib\", \"inherited\": true}]}"
+  let transitiveVCVio := "{\"packages\": [{\"name\": \"VCVio\", \"inherited\": true}, {\"name\": \"mathlib\", \"inherited\": false}]}"
+  let noVCVio := "{\"packages\": [{\"name\": \"mathlib\", \"inherited\": false}]}"
+  result ← test "direct (inherited:false) VCVio → detected" (manifestDeclaresVCVio directVCVio) result
+  result ← test "transitive (inherited:true) VCVio → NOT detected" (!manifestDeclaresVCVio transitiveVCVio) result
+  result ← test "no VCVio package → not detected" (!manifestDeclaresVCVio noVCVio) result
+  result ← test "unparseable manifest → not detected" (!manifestDeclaresVCVio "{not json") result
+  result ← test "VCVio only in a comment/url → not detected"
+    (!manifestDeclaresVCVio "{\"comment\": \"uses VCV-io\", \"packages\": []}") result
+  -- Realistic entry shape: a direct dep carries url/type/rev/inputRev fields too;
+  -- extra fields must not defeat the `name`+`inherited` match.
+  let realShape := "{\"version\": \"1.1.0\", \"packagesDir\": \".lake/packages\", \"packages\": [{\"type\": \"git\", \"name\": \"VCVio\", \"url\": \"https://github.com/dtumad/VCV-io.git\", \"rev\": \"1e984d2\", \"inputRev\": \"main\", \"inherited\": false, \"configFile\": \"lakefile.toml\"}, {\"name\": \"mathlib\", \"inherited\": true}]}"
+  result ← test "direct VCVio dep with realistic extra fields → detected"
+    (manifestDeclaresVCVio realShape) result
+  -- Fail-closed default: an entry with NO `inherited` field is treated as
+  -- transitive (⇒ not detected). Documents the chosen default; the import-graph
+  -- signal still backstops a genuine direct dep whose manifest omits the field.
+  let absentInherited := "{\"packages\": [{\"name\": \"VCVio\", \"url\": \"x\"}]}"
+  result ← test "VCVio entry with absent `inherited` → fail-closed not detected"
+    (!manifestDeclaresVCVio absentInherited) result
+  -- Malformed `packages` (object, not array) must not throw → not detected.
+  result ← test "malformed packages (not an array) → not detected"
+    (!manifestDeclaresVCVio "{\"packages\": {\"name\": \"VCVio\"}}") result
   return result
 
 -- Build-time drift-resolver check: a guaranteed-present core name resolves with
@@ -1231,6 +1257,25 @@ def testClassifyFixpointOrder (result : TestResult) : IO TestResult := do
     ((clsOf ord1 "App.gd").map (·.category) == some .ambiguous) result
   result ← test "reach-both gd → ambiguous (shuffled order)"
     ((clsOf ord2 "App.gd").map (·.category) == some .ambiguous) result
+
+  -- Pins the staged classifier's FIRST-VERDICT-WINS contract: a verdict reached
+  -- in one pass is final, even if a *later*-promoted, strictly-nearer anchor would
+  -- have decided it differently. `dTie` ties corr@2 (via gMid→correctnessExp) and
+  -- sec@2 (via passSec→securityExp) in pass 1 — gMid is not yet an anchor — so it
+  -- locks `ambiguous`. gMid is promoted (correctness) the same pass; were dTie
+  -- re-walked it would now see corr@1 < sec@2 and flip to correctness, but it is
+  -- not reconsidered. This is deliberate (and unchanged by the fixpoint refactor);
+  -- the test guards against a silent semantics drift, not asserts the ideal.
+  let corrExp := mkDeclI "App.correctnessExp" .def .game
+  let secExp := mkDeclI "App.securityExp" .def .game
+  let gMid := mkDeclI "App.gMid" .def .game none #[] #["App.correctnessExp"]
+  let passSec := mkDeclI "App.passSec" .def .other none #["App.securityExp"] #[]
+  let dTie := mkDeclI "App.dTie" .def .game none #[] #["App.gMid", "App.passSec"]
+  let stick := #[corrExp, secExp, gMid, passSec, dTie]
+  result ← test "later-promoted nearer anchor does NOT revise an earlier verdict (dTie stays ambiguous)"
+    ((clsOf stick "App.dTie").map (·.category) == some .ambiguous) result
+  result ← test "the later-promoted anchor itself is correctness (gMid)"
+    ((clsOf stick "App.gMid").map (·.category) == some .correctness) result
   return result
 
 def testClassifyAttrShapeAndInstance (result : TestResult) : IO TestResult := do

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -1319,6 +1319,78 @@ def testClassifyLinkEdges (result : TestResult) : IO TestResult := do
     ((clsOf dl "App.amb").map (·.scheme) == some #[`App.OneScheme]) result
   return result
 
+def testUnifyClassification (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing unifyAtom attaches classification (commit-5a glue)..."
+  let atom : Atom := {
+    name := "probe:App.thm"
+    displayName := "thm"
+    dependencies := #[]
+    codeModule := "App"
+    codePath := "App.lean"
+    codeText := none
+    kind := .theorem
+  }
+  let cls : Classification := { category := .correctness, «via» := .naming, scheme := #[`App.CKAScheme] }
+  let ua := unifyAtom atom none (some cls)
+  result ← test "unifyAtom sets classification when present"
+    (ua.classification.map (·.category) == some .correctness) result
+  result ← test "unifyAtom classification link preserved"
+    (ua.classification.map (·.scheme) == some #[`App.CKAScheme]) result
+  let uaNone := unifyAtom atom none none
+  result ← test "unifyAtom classification absent by default" (uaNone.classification == none) result
+  -- the classifier keys by raw Name; Extract indexes by the probe-prefixed atom name
+  result ← test "probe-prefixed key matches atom name"
+    (addProbePrefix (`App.thm).toString == atom.name) result
+  return result
+
+def testBuildClassMap (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing buildClassMap keys by probe-prefixed name..."
+  let cls1 : Classification := { category := .scheme, «via» := .naming }
+  let cls2 : Classification := { category := .correctness, «via» := .naming, construction := #[`App.c] }
+  let m := buildClassMap #[(`App.CKAScheme, cls1), (`App.thm, cls2)]
+  result ← test "buildClassMap: scheme keyed by probe:name"
+    ((m["probe:App.CKAScheme"]?).map (·.category) == some .scheme) result
+  result ← test "buildClassMap: theorem keyed by probe:name"
+    ((m["probe:App.thm"]?).map (·.category) == some .correctness) result
+  result ← test "buildClassMap: unknown name → none" ((m["probe:App.nope"]?).isNone) result
+  -- the classifier only runs for the security-protocol class
+  result ← test "classifier runs for security-protocol" (isSecurityProtocolClass (some "security-protocol")) result
+  result ← test "classifier skips other class" (!isSecurityProtocolClass (some "other-class")) result
+  result ← test "classifier skips no class" (!isSecurityProtocolClass none) result
+  return result
+
+def testEnrichPreservesClassification (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing transitive enrichment preserves classification..."
+  let cls : Classification := { category := .security, «via» := .naming, scheme := #[`App.S] }
+  let atom : UnifiedAtom := {
+    name := "probe:App.thm"
+    displayName := "thm"
+    dependencies := #[]
+    codeModule := "App"
+    codePath := "App.lean"
+    codeText := none
+    kind := .theorem
+    verificationStatus := some .verified
+    classification := some cls
+  }
+  let (enriched, _, _, _) := enrichTransitiveVerification #[atom]
+  match enriched[0]? with
+  | some out =>
+    result ← test "verified atom upgraded to transitively-verified"
+      (out.verificationStatus == some .transitivelyVerified) result
+    result ← test "classification survives the enrichment record-update"
+      (out.classification.map (fun c => (c.category, c.scheme)) == some (.security, #[`App.S])) result
+  | none =>
+    IO.println "  ✗ enriched atom missing"
+    result := result.add false
+  return result
+
 def testClassifyMisuseIgnored (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -1330,6 +1402,30 @@ def testClassifyMisuseIgnored (result : TestResult) : IO TestResult := do
   result ← test "scheme_def on theorem ignored → classified by naming"
     (cls.map (·.category) == some .correctness) result
   result ← test "ignored scheme_def is diagnosed" (diags.any (containsSubstring · "scheme_def")) result
+  return result
+
+def testClassifyAttrAuthority (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing attribute authority + property-def tie via (final review fixes)..."
+  -- #1: a property def reaching both categories at equal depth via naming anchors
+  -- must be ambiguous with via=naming (the weakest tier), not hard-coded type.
+  let corrGame := mkDeclI "App.correctnessExp" .def .game
+  let secGame := mkDeclI "App.securityExp" .def .game
+  let gboth := mkDeclI "App.gboth" .def .game none #[] #["App.correctnessExp", "App.securityExp"]
+  result ← test "property-def reach tie → ambiguous via naming (weakest tier)"
+    ((clsOf #[corrGame, secGame, gboth] "App.gboth").map (fun c => (c.category, c.via))
+      == some (.ambiguous, .naming)) result
+  -- #2: a property tag must win over construction type-inference even when the
+  -- def returns a scheme (attributes are authoritative).
+  let scheme := mkDeclI "App.CKAScheme" .structure
+  let taggedSec := mkDeclI "App.weirdSecProp" .def .other (head := "App.CKAScheme") (attrs := #["security_spec"])
+  result ← test "@[security_spec] def returning a scheme → security, not construction"
+    ((clsOf #[scheme, taggedSec] "App.weirdSecProp").map (·.category) == some .security) result
+  let bothTags := mkDeclI "App.weirdBoth" .def .other (head := "App.CKAScheme")
+    (attrs := #["correctness_spec", "security_spec"])
+  result ← test "conflicting tags on scheme-returning def → ambiguous, not construction"
+    ((clsOf #[scheme, bothTags] "App.weirdBoth").map (·.category) == some .ambiguous) result
   return result
 
 def testViewHelpers (result : TestResult) : IO TestResult := do
@@ -2963,6 +3059,10 @@ def main : IO UInt32 := do
   result ← testClassifyWalkEdges result
   result ← testClassifyLinkEdges result
   result ← testClassifyMisuseIgnored result
+  result ← testClassifyAttrAuthority result
+  result ← testUnifyClassification result
+  result ← testBuildClassMap result
+  result ← testEnrichPreservesClassification result
   result ← testViewHelpers result
   result ← testStubEntryJson result
   result ← testMoleculesOutputJson result

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -778,6 +778,171 @@ def testUnifiedAtomJson (result : TestResult) : IO TestResult := do
   result ← test "UnifiedAtom specs absent when empty" unsAbsent result
   return result
 
+-- Build-time registration test for the security-protocol classification tags.
+-- These declarations only elaborate if the attributes are registered (an
+-- unregistered tag is an "unknown attribute" error). The `run_cmd` below then
+-- confirms `hasTag` — the API the classifier will use — reads them back.
+@[scheme_def] def testTaggedScheme : Nat := 0
+@[construction_def] def testTaggedConstruction : Nat := 0
+@[correctness_spec] theorem testTaggedCorrectness : testTaggedScheme = 0 := rfl
+@[security_spec] theorem testTaggedSecurity : testTaggedConstruction = 0 := rfl
+
+open Lean Elab Command in
+run_cmd do
+  let env ← getEnv
+  let ok := ProbeLean.schemeDefAttr.hasTag env ``testTaggedScheme
+    && ProbeLean.constructionDefAttr.hasTag env ``testTaggedConstruction
+    && ProbeLean.correctnessSpecAttr.hasTag env ``testTaggedCorrectness
+    && ProbeLean.securitySpecAttr.hasTag env ``testTaggedSecurity
+  unless ok do
+    throwError "classification attributes registered but hasTag did not read them back"
+
+def testClassificationJson (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing ClassCategory / ClassVia round-trips..."
+  let catRt := match Lean.FromJson.fromJson? (Lean.toJson ClassCategory.construction) (α := ClassCategory) with
+    | .ok .construction => true | _ => false
+  let viaRt := match Lean.FromJson.fromJson? (Lean.toJson ClassVia.naming) (α := ClassVia) with
+    | .ok .naming => true | _ => false
+  result ← test "ClassCategory round-trips" catRt result
+  result ← test "ClassVia round-trips" viaRt result
+  result ← test "ClassCategory scheme toJson" (Lean.toJson ClassCategory.scheme == "scheme") result
+  result ← test "ClassVia attribute toJson" (Lean.toJson ClassVia.attribute == "attribute") result
+
+  IO.println ""
+  IO.println "Testing Classification link serialization (singular = string)..."
+  let cls1 : Classification := {
+    category := .correctness
+    «via» := .naming
+    scheme := #[`Foo.Scheme]
+    construction := #[`Foo.construction]
+  }
+  let cls1Json := Lean.toJson cls1
+  let schemeIsString := match cls1Json.getObjValAs? String "scheme" with
+    | .ok s => s == "probe:Foo.Scheme" | _ => false
+  let consIsString := match cls1Json.getObjValAs? String "construction" with
+    | .ok s => s == "probe:Foo.construction" | _ => false
+  result ← test "scheme link serialises as string when singular" schemeIsString result
+  result ← test "construction link serialises as string when singular" consIsString result
+  let cls1Rt := match Lean.FromJson.fromJson? cls1Json (α := Classification) with
+    | .ok c => c.category == .correctness && c.via == .naming
+        && c.scheme == #[`Foo.Scheme]
+        && c.construction == #[`Foo.construction]
+    | .error _ => false
+  result ← test "Classification with singular links round-trips" cls1Rt result
+
+  IO.println ""
+  IO.println "Testing Classification link serialization (ambiguous = array)..."
+  let cls2 : Classification := {
+    category := .security
+    «via» := .type
+    scheme := #[`Foo.SchemeA, `Foo.SchemeB]
+  }
+  let cls2Json := Lean.toJson cls2
+  let schemeIsArray := match cls2Json.getObjValAs? (Array String) "scheme" with
+    | .ok arr => arr.size == 2 && arr[0]! == "probe:Foo.SchemeA" | _ => false
+  let consAbsent := match cls2Json.getObjVal? "construction" with
+    | .ok _ => false | .error _ => true
+  result ← test "scheme link serialises as array when ambiguous" schemeIsArray result
+  result ← test "empty construction link omitted" consAbsent result
+  let cls2Rt := match Lean.FromJson.fromJson? cls2Json (α := Classification) with
+    | .ok c => c.scheme.size == 2 && c.construction.isEmpty
+    | .error _ => false
+  result ← test "Classification with array link round-trips" cls2Rt result
+  -- exact contents + deterministic (sorted) order of the ambiguous array
+  let cls2ArrOk := match cls2Json.getObjValAs? (Array String) "scheme" with
+    | .ok arr => arr == #["probe:Foo.SchemeA", "probe:Foo.SchemeB"] | _ => false
+  result ← test "ambiguous scheme array has exact sorted contents" cls2ArrOk result
+  -- unsorted + duplicate input normalises to sorted, deduped output
+  let clsDup : Classification := {
+    category := .security
+    «via» := .type
+    scheme := #[`Foo.SchemeB, `Foo.SchemeA, `Foo.SchemeB]
+  }
+  let clsDupOk := match (Lean.toJson clsDup).getObjValAs? (Array String) "scheme" with
+    | .ok arr => arr == #["probe:Foo.SchemeA", "probe:Foo.SchemeB"] | _ => false
+  result ← test "link names dedupe and stable-sort on serialisation" clsDupOk result
+
+  IO.println ""
+  IO.println "Testing Classification field ordering is pinned..."
+  -- construction must precede scheme in the serialised object (design doc order)
+  let orderJson := (Lean.toJson cls1).compress
+  let consIdx := (orderJson.splitOn "\"construction\"").head!.length
+  let schemeIdx := (orderJson.splitOn "\"scheme\"").head!.length
+  result ← test "construction key precedes scheme key" (consIdx < schemeIdx) result
+
+  IO.println ""
+  IO.println "Testing Classification rejects malformed links..."
+  let mkBad (schemeVal : Lean.Json) : Lean.Json :=
+    Lean.Json.mkObj [
+      ("category", Lean.toJson "scheme"),
+      ("via", Lean.toJson "type"),
+      ("scheme", schemeVal)
+    ]
+  let rejNumber := match Lean.FromJson.fromJson? (mkBad (Lean.toJson (42 : Nat))) (α := Classification) with
+    | .ok _ => false | .error _ => true
+  let rejMixed := match Lean.FromJson.fromJson? (mkBad (Lean.Json.arr #[Lean.toJson "probe:Foo.A", Lean.toJson (7 : Nat)])) (α := Classification) with
+    | .ok _ => false | .error _ => true
+  let rejNull := match Lean.FromJson.fromJson? (mkBad Lean.Json.null) (α := Classification) with
+    | .ok _ => false | .error _ => true
+  result ← test "rejects scheme link that is a number" rejNumber result
+  result ← test "rejects scheme link array with non-string element" rejMixed result
+  result ← test "rejects scheme link that is present-but-null" rejNull result
+  -- an omitted link key is the normal unresolved case → empty, no error
+  let okAbsent := match Lean.FromJson.fromJson?
+      (Lean.Json.mkObj [("category", Lean.toJson "scheme"), ("via", Lean.toJson "type")]) (α := Classification) with
+    | .ok c => c.scheme.isEmpty && c.construction.isEmpty | .error _ => false
+  result ← test "absent link key parses as empty" okAbsent result
+
+  IO.println ""
+  IO.println "Testing UnifiedAtom classification field..."
+  let atomCls : UnifiedAtom := {
+    name := "probe:Test.thm"
+    displayName := "thm"
+    dependencies := #[]
+    codeModule := "Test"
+    codePath := "Test.lean"
+    codeText := none
+    kind := .theorem
+    verificationStatus := some .verified
+    classification := some cls1
+  }
+  let atomClsJson := Lean.toJson atomCls
+  let clsPresent := match atomClsJson.getObjVal? "classification" with
+    | .ok _ => true | .error _ => false
+  result ← test "classification present in atom JSON when set" clsPresent result
+  let atomClsRt := match Lean.FromJson.fromJson? atomClsJson (α := UnifiedAtom) with
+    | .ok a => match a.classification with
+      | some c => c.category == .correctness
+      | none => false
+    | .error _ => false
+  result ← test "atom classification round-trips" atomClsRt result
+  let atomNoCls : UnifiedAtom := { atomCls with classification := none }
+  let clsAbsent := match (Lean.toJson atomNoCls).getObjVal? "classification" with
+    | .ok _ => false | .error _ => true
+  result ← test "classification absent from atom JSON when none" clsAbsent result
+
+  IO.println ""
+  IO.println "Testing SourceInfo class field..."
+  let srcWithClass : SourceInfo := {
+    repo := "https://example.com/repo", commit := "abc", package := "Pkg"
+    packageVersion := "1.0", sourceClass := some "security-protocol"
+  }
+  let srcJson := Lean.toJson srcWithClass
+  let classPresent := match srcJson.getObjValAs? String "class" with
+    | .ok s => s == "security-protocol" | _ => false
+  result ← test "source.class present in JSON when set" classPresent result
+  let srcRt := match Lean.FromJson.fromJson? srcJson (α := SourceInfo) with
+    | .ok s => s.sourceClass == some "security-protocol"
+    | .error _ => false
+  result ← test "source.class round-trips" srcRt result
+  let srcNoClass : SourceInfo := { srcWithClass with sourceClass := none }
+  let classAbsent := match (Lean.toJson srcNoClass).getObjVal? "class" with
+    | .ok _ => false | .error _ => true
+  result ← test "source.class absent from JSON when none" classAbsent result
+  return result
+
 def testViewHelpers (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -2393,6 +2558,7 @@ def main : IO UInt32 := do
   result ← testSorryDetection result
   result ← testProofsOutputJson result
   result ← testUnifiedAtomJson result
+  result ← testClassificationJson result
   result ← testViewHelpers result
   result ← testStubEntryJson result
   result ← testMoleculesOutputJson result

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -1003,6 +1003,53 @@ def testDetectClass (result : TestResult) : IO TestResult := do
     (!moduleListIndicatesSecurityProtocol #[]) result
   return result
 
+-- Build-time drift-resolver check: a guaranteed-present core name resolves with
+-- no warning; a bogus FQN produces exactly one warning. Uses this test module's
+-- own environment (Lean core: `Nat`/`List` present).
+open Lean Elab Command in
+run_cmd do
+  let env ← getEnv
+  let present := Catalogue.resolveAnchors env #[`Nat, `List]
+  let bogus := Catalogue.resolveAnchors env #[`Probe.Definitely.Not.A.Real.Name]
+  unless present.isEmpty do
+    throwError "resolveAnchors flagged core names that exist: {present}"
+  unless bogus.size == 1 do
+    throwError "resolveAnchors should flag exactly one bogus name, got {bogus.size}"
+  -- No VCVio scheme types are loaded in this test env, so every anchor's guard
+  -- is absent → family-conditional drift must stay silent (no false alarms).
+  let drift := Catalogue.driftWarnings env
+  unless drift.isEmpty do
+    throwError "driftWarnings should be empty in a non-VCVio env, got: {drift}"
+
+def testDrift (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing classification catalogue is well-formed..."
+  let noDups (a : Array Lean.Name) : Bool := a.toList.eraseDups.length == a.size
+  result ← test "scheme types non-empty" (Catalogue.vcvioSchemeTypes.size > 0) result
+  result ← test "game heads non-empty" (Catalogue.gameHeads.size > 0) result
+  result ← test "correctness anchors non-empty" (Catalogue.correctnessAnchors.size > 0) result
+  result ← test "security anchors non-empty" (Catalogue.securityAnchors.size > 0) result
+  result ← test "scheme types deduped" (noDups Catalogue.vcvioSchemeTypes) result
+  result ← test "game heads deduped" (noDups Catalogue.gameHeads) result
+  result ← test "correctness anchors deduped" (noDups Catalogue.correctnessAnchors) result
+  result ← test "security anchors deduped" (noDups Catalogue.securityAnchors) result
+  result ← test "algebra guard deduped" (noDups Catalogue.mathlibAlgebraGuard) result
+  -- categories must be disjoint (no anchor miscategorised into two buckets)
+  result ← test "correctness ∩ security = ∅"
+    (Catalogue.correctnessAnchors.all fun n => !Catalogue.securityAnchors.contains n) result
+  let props := Catalogue.correctnessAnchors ++ Catalogue.securityAnchors
+  result ← test "scheme types ∩ property anchors = ∅"
+    (Catalogue.vcvioSchemeTypes.all fun n => !props.contains n) result
+  result ← test "no anonymous anchors" (Catalogue.allAnchors.all fun n => !n.isAnonymous) result
+  -- guardOf: scheme-namespaced anchors guard on their scheme type; top-level → none
+  result ← test "guardOf scheme-namespaced anchor"
+    (Catalogue.guardOf `KEMScheme.IND_CCA_Advantage == some `KEMScheme) result
+  result ← test "guardOf nested-namespaced anchor"
+    (Catalogue.guardOf `AsymmEncAlg.ExplicitCoins.OW_CPA_Game == some `AsymmEncAlg.ExplicitCoins) result
+  result ← test "guardOf top-level anchor is none" (Catalogue.guardOf `SecExp == none) result
+  return result
+
 def testViewHelpers (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -2621,6 +2668,7 @@ def main : IO UInt32 := do
   result ← testClassificationJson result
   result ← testCodomainShape result
   result ← testDetectClass result
+  result ← testDrift result
   result ← testViewHelpers result
   result ← testStubEntryJson result
   result ← testMoleculesOutputJson result

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -803,11 +803,15 @@ def testClassificationJson (result : TestResult) : IO TestResult := do
   IO.println "Testing ClassCategory / ClassVia round-trips..."
   let catRt := match Lean.FromJson.fromJson? (Lean.toJson ClassCategory.construction) (α := ClassCategory) with
     | .ok .construction => true | _ => false
+  let ambRt := match Lean.FromJson.fromJson? (Lean.toJson ClassCategory.ambiguous) (α := ClassCategory) with
+    | .ok .ambiguous => true | _ => false
   let viaRt := match Lean.FromJson.fromJson? (Lean.toJson ClassVia.naming) (α := ClassVia) with
     | .ok .naming => true | _ => false
   result ← test "ClassCategory round-trips" catRt result
+  result ← test "ClassCategory ambiguous round-trips" ambRt result
   result ← test "ClassVia round-trips" viaRt result
   result ← test "ClassCategory scheme toJson" (Lean.toJson ClassCategory.scheme == "scheme") result
+  result ← test "ClassCategory ambiguous toJson" (Lean.toJson ClassCategory.ambiguous == "ambiguous") result
   result ← test "ClassVia attribute toJson" (Lean.toJson ClassVia.attribute == "attribute") result
 
   IO.println ""
@@ -1048,6 +1052,284 @@ def testDrift (result : TestResult) : IO TestResult := do
   result ← test "guardOf nested-namespaced anchor"
     (Catalogue.guardOf `AsymmEncAlg.ExplicitCoins.OW_CPA_Game == some `AsymmEncAlg.ExplicitCoins) result
   result ← test "guardOf top-level anchor is none" (Catalogue.guardOf `SecExp == none) result
+  return result
+
+/-- Build a synthetic `DeclInfo` for classifier tests. -/
+def mkDeclI (nm : String) (kind : DeclKind) (shape : CodomainShape := .other)
+    (head : Option String := none) (typeDeps : Array String := #[])
+    (termDeps : Array String := #[]) (attrs : Array String := #[]) : DeclInfo :=
+  { name := nm.toName
+    displayName := getDisplayName nm.toName
+    moduleName := `Test
+    kind := kind
+    dependencies := (typeDeps ++ termDeps).map (·.toName)
+    typeDependencies := typeDeps.map (·.toName)
+    termDependencies := termDeps.map (·.toName)
+    sourceInfo := some { linesStart := 1, linesEnd := 1 }
+    codomainHead := head.map (·.toName)
+    codomainShape := shape
+    classAttributes := attrs }
+
+/-- Run the classifier and look up one atom's classification by code-name. -/
+def clsOf (decls : Array DeclInfo) (nm : String) : Option Classification :=
+  let (res, _) := Classify.classify decls
+  (res.find? (·.1 == nm.toName)).map (·.2)
+
+def testClassifySchemes (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing scheme classification..."
+  let decls : Array DeclInfo := #[
+    mkDeclI "App.CKAScheme" .structure,                                   -- naming *Scheme
+    mkDeclI "App.AEAD" .structure (attrs := #["scheme_def"]),             -- attribute
+    mkDeclI "App.SymmEncAlg" .structure,                                  -- naming *Alg
+    mkDeclI "App.BoolAlg" .structure,                                     -- algebra guard → not scheme
+    mkDeclI "App.fooScheme" .def,                                         -- *Scheme but not a structure
+    mkDeclI "App.AlgebraicMAC" .structure ]                              -- no *Scheme/*Alg suffix
+  let cat (n : String) := (clsOf decls n).map (·.category)
+  result ← test "structure *Scheme → scheme (naming)" (cat "App.CKAScheme" == some .scheme) result
+  result ← test "@[scheme_def] → scheme (attribute)"
+    ((clsOf decls "App.AEAD").map (fun c => (c.category, c.via)) == some (.scheme, .attribute)) result
+  result ← test "structure *Alg → scheme" (cat "App.SymmEncAlg" == some .scheme) result
+  result ← test "BoolAlg guarded → not scheme" (cat "App.BoolAlg" == none) result
+  result ← test "non-structure *Scheme → not scheme" (cat "App.fooScheme" == none) result
+  result ← test "untagged AlgebraicMAC → not scheme (needs tag)" (cat "App.AlgebraicMAC" == none) result
+  return result
+
+def testClassifyConstructions (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing construction classification + scheme link..."
+  let decls : Array DeclInfo := #[
+    mkDeclI "App.CKAScheme" .structure,
+    mkDeclI "App.ddhCKA" .def (head := "App.CKAScheme"),                  -- returns project scheme
+    mkDeclI "App.myKEM" .def (head := "KEMScheme"),                       -- returns VCVio scheme
+    mkDeclI "App.tagged" .def (attrs := #["construction_def"]) ]
+  result ← test "def returning project scheme → construction (type)"
+    ((clsOf decls "App.ddhCKA").map (·.category) == some .construction) result
+  result ← test "construction → scheme link"
+    ((clsOf decls "App.ddhCKA").map (·.scheme) == some #[`App.CKAScheme]) result
+  result ← test "def returning VCVio scheme → construction, scheme link absent"
+    ((clsOf decls "App.myKEM").map (fun c => (c.category, c.scheme)) == some (.construction, #[])) result
+  result ← test "@[construction_def] → construction (attribute)"
+    ((clsOf decls "App.tagged").map (·.via) == some .attribute) result
+  return result
+
+def testClassifyPromotionWalk (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing property promotion + theorem walk..."
+  let scheme := mkDeclI "App.CKAScheme" .structure
+  let cons := mkDeclI "App.ddhCKA" .def (head := "App.CKAScheme")
+  let corrExp := mkDeclI "App.correctnessExp" .def .game none #[] #[]      -- naming → correctness, promoted
+  let thm := mkDeclI "App.correctness" .theorem .other none
+    #["App.correctnessExp", "App.ddhCKA"] #[]                             -- reaches promoted anchor
+  let decls := #[scheme, cons, corrExp, thm]
+  result ← test "project game *correct* → correctness (naming)"
+    ((clsOf decls "App.correctnessExp").map (·.category) == some .correctness) result
+  result ← test "theorem reaches promoted anchor → correctness"
+    ((clsOf decls "App.correctness").map (·.category) == some .correctness) result
+  result ← test "theorem inherits weakest via (naming)"
+    ((clsOf decls "App.correctness").map (·.via) == some .naming) result
+  -- order-independence: shuffle the input, expect identical verdicts
+  let shuffled := #[thm, corrExp, scheme, cons]
+  result ← test "promotion fixed point is order-independent"
+    ((clsOf shuffled "App.correctness").map (·.category)
+      == (clsOf decls "App.correctness").map (·.category)) result
+  return result
+
+def testClassifyWalkTieAndBound (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing equal-depth tie → ambiguous, and the depth bound..."
+  let corrExp := mkDeclI "App.correctnessExp" .def .game
+  let secExp := mkDeclI "App.securityExp" .def .game
+  let tieThm := mkDeclI "App.both" .theorem .other none
+    #["App.correctnessExp", "App.securityExp"] #[]
+  result ← test "equal-depth correctness/security tie → ambiguous"
+    ((clsOf #[corrExp, secExp, tieThm] "App.both").map (·.category) == some .ambiguous) result
+  -- depth bound: a 17-node pass-through chain puts the anchor at depth 18 (> 16)
+  let chain : Array DeclInfo := (List.range 17).toArray.map fun i =>
+    let next := if i < 16 then s!"Bound.c{i+1}" else "Bound.securityExp"
+    mkDeclI s!"Bound.c{i}" .def .other none #[next] #[]
+  let anchor := mkDeclI "Bound.securityExp" .def .game
+  let farThm := mkDeclI "Bound.thm" .theorem .other none #["Bound.c0"] #[]
+  let boundDecls := chain.push anchor |>.push farThm
+  result ← test "anchor beyond depth 16 → theorem unclassified"
+    ((clsOf boundDecls "Bound.thm").isNone) result
+  -- same anchor at depth 2 IS reached
+  let nearThm := mkDeclI "Near.thm" .theorem .other none #["App.securityExp"] #[]
+  result ← test "anchor within bound → classified"
+    ((clsOf #[secExp, nearThm] "Near.thm").map (·.category) == some .security) result
+  return result
+
+def testClassifyLinks (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing link resolution (fail-closed)..."
+  let scheme := mkDeclI "App.CKAScheme" .structure
+  let cons := mkDeclI "App.ddhCKA" .def (head := "App.CKAScheme")
+  let corrExp := mkDeclI "App.correctnessExp" .def .game
+  let thm := mkDeclI "App.correctness" .theorem .other none
+    #["App.correctnessExp", "App.ddhCKA"] #[]
+  let decls := #[scheme, cons, corrExp, thm]
+  result ← test "property → construction link (unique)"
+    ((clsOf decls "App.correctness").map (·.construction) == some #[`App.ddhCKA]) result
+  result ← test "property → scheme link (via its construction)"
+    ((clsOf decls "App.correctness").map (·.scheme) == some #[`App.CKAScheme]) result
+  -- orphan: a theorem reaching no anchor and naming nothing → absent (no links)
+  let orphan := mkDeclI "App.helperLemma" .theorem .other none #["App.someList"] #[]
+  result ← test "orphan theorem → unclassified" ((clsOf #[orphan] "App.helperLemma").isNone) result
+  -- scheme-level property: game names a scheme but no construction → scheme link only
+  let schemeLevel := mkDeclI "App.correctnessExp2" .def .game none #["App.CKAScheme"] #[]
+  let dl := #[scheme, schemeLevel]
+  result ← test "scheme-level property → scheme link, no construction"
+    ((clsOf dl "App.correctnessExp2").map (fun c => (c.construction, c.scheme))
+      == some (#[], #[`App.CKAScheme])) result
+  return result
+
+def testClassifyConflicts (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing conflicting tags → ambiguous..."
+  let bothTags := mkDeclI "App.weird" .theorem .other none #[] #[] #["correctness_spec", "security_spec"]
+  let (res, diags) := Classify.classify #[bothTags]
+  let cls := (res.find? (·.1 == `App.weird)).map (·.2)
+  result ← test "both *_spec tags → ambiguous" (cls.map (·.category) == some .ambiguous) result
+  result ← test "conflict emits a diagnostic" (diags.any (containsSubstring · "conflicting")) result
+  -- kind-incompatible tag is ignored + diagnosed, decl falls through
+  let misuse := mkDeclI "App.notAStruct" .theorem .other none #[] #[] #["scheme_def"]
+  let (_, diags2) := Classify.classify #[misuse]
+  result ← test "scheme_def on theorem diagnosed" (diags2.any (containsSubstring · "scheme_def")) result
+  return result
+
+/-- A pass-through chain `pre0 → pre1 → … → last` of non-property `.other`
+defs (so they are not promoted; they just relay the walk). -/
+def chainTo (pre : String) (n : Nat) (last : String) : Array DeclInfo :=
+  (List.range n).toArray.map fun i =>
+    let next := if i + 1 < n then s!"{pre}{i+1}" else last
+    mkDeclI s!"{pre}{i}" .def .other none #[next] #[]
+
+def testClassifyFixpointOrder (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing type-reach fixed point is order-independent..."
+  -- correctnessExp/securityExp: naming anchors. gx reaches corr, gy reaches sec,
+  -- gd reaches BOTH (through gx/gy bodies) → must be ambiguous regardless of the
+  -- order gx/gd/gy are promoted in (the per-pass snapshot guarantees this).
+  let corrGame := mkDeclI "App.correctnessExp" .def .game
+  let secGame := mkDeclI "App.securityExp" .def .game
+  let gx := mkDeclI "App.gx" .def .game none #[] #["App.correctnessExp"]
+  let gy := mkDeclI "App.gy" .def .game none #[] #["App.securityExp"]
+  let gd := mkDeclI "App.gd" .def .game none #[] #["App.gx", "App.gy"]
+  -- gd sits BETWEEN gx and gy in the fold order — the order that broke before.
+  let ord1 := #[corrGame, secGame, gx, gd, gy]
+  let ord2 := #[gd, gy, gx, secGame, corrGame]
+  result ← test "gx reaches correctness only" ((clsOf ord1 "App.gx").map (·.category) == some .correctness) result
+  result ← test "gy reaches security only" ((clsOf ord1 "App.gy").map (·.category) == some .security) result
+  result ← test "reach-both gd → ambiguous (fold order gx,gd,gy)"
+    ((clsOf ord1 "App.gd").map (·.category) == some .ambiguous) result
+  result ← test "reach-both gd → ambiguous (shuffled order)"
+    ((clsOf ord2 "App.gd").map (·.category) == some .ambiguous) result
+  return result
+
+def testClassifyAttrShapeAndInstance (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing attributes are shape-independent + instance constructions..."
+  -- a transformer-stacked game has shape `other`, yet @[security_spec] must win
+  let txGame := mkDeclI "App.txSec" .def .other none #[] #[] #["security_spec"]
+  let (res, diags) := Classify.classify #[txGame]
+  let txCls := (res.find? (·.1 == `App.txSec)).map (·.2)
+  result ← test "@[security_spec] on .other def → security (attribute)"
+    (txCls.map (fun c => (c.category, c.via)) == some (.security, .attribute)) result
+  result ← test "@[security_spec] on .other def NOT diagnosed as misuse"
+    (!diags.any (containsSubstring · "non-property")) result
+  -- instance returning a scheme is a construction
+  let scheme := mkDeclI "App.CKAScheme" .structure
+  let inst := mkDeclI "App.ckaInst" .instance .other (head := "App.CKAScheme")
+  result ← test "instance returning a scheme → construction"
+    ((clsOf #[scheme, inst] "App.ckaInst").map (·.category) == some .construction) result
+  return result
+
+def testClassifyViaWeakest (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing weakest-tier via at equal depth is order-independent..."
+  -- KEMScheme.CorrectExp is a catalogued (via:type) correctness anchor; the
+  -- project correctnessExp is via:naming. Reaching both at depth 1 → naming.
+  let projCorr := mkDeclI "App.correctnessExp" .def .game
+  let thm := mkDeclI "App.bothCorr" .theorem .other none
+    #["KEMScheme.CorrectExp", "App.correctnessExp"] #[]
+  result ← test "same-depth corr anchors (type+naming) → via naming"
+    ((clsOf #[projCorr, thm] "App.bothCorr").map (fun c => (c.category, c.via))
+      == some (.correctness, .naming)) result
+  return result
+
+def testClassifyWalkEdges (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing walk edges: shallower-wins, depth boundary, cycles..."
+  let corrA := mkDeclI "App.correctnessExp" .def .game
+  let secA := mkDeclI "App.securityExp" .def .game
+  -- shallower wins: corr at depth 1, sec at depth 2 (through a pass-through) → correctness
+  let passSec := mkDeclI "App.passSec" .def .other none #["App.securityExp"] #[]
+  let shThm := mkDeclI "App.shallow" .theorem .other none #["App.correctnessExp", "App.passSec"] #[]
+  result ← test "strictly-shallower category wins (corr@1 vs sec@2)"
+    ((clsOf #[corrA, secA, passSec, shThm] "App.shallow").map (·.category) == some .correctness) result
+  -- depth boundary: anchor at depth 16 is reached; at depth 17 it is not
+  let c16 := chainTo "R16.c" 15 "App.correctnessExp"      -- c0..c14 (15) → anchor @ depth 16
+  let thm16 := mkDeclI "R16.thm" .theorem .other none #["R16.c0"] #[]
+  result ← test "anchor at depth 16 → reached"
+    ((clsOf (#[corrA] ++ c16 |>.push thm16) "R16.thm").map (·.category) == some .correctness) result
+  let c17 := chainTo "R17.c" 16 "App.correctnessExp"      -- c0..c15 (16) → anchor @ depth 17
+  let thm17 := mkDeclI "R17.thm" .theorem .other none #["R17.c0"] #[]
+  result ← test "anchor at depth 17 → not reached" ((clsOf (#[corrA] ++ c17 |>.push thm17) "R17.thm").isNone) result
+  -- cycle: a self/mutually-referential dep must terminate (visited set)
+  let cyc := mkDeclI "App.cyc" .def .other none #["App.cyc", "App.correctnessExp"] #[]
+  let cycThm := mkDeclI "App.cycThm" .theorem .other none #["App.cyc"] #[]
+  result ← test "cyclic dep terminates and still reaches anchor"
+    ((clsOf #[corrA, cyc, cycThm] "App.cycThm").map (·.category) == some .correctness) result
+  return result
+
+def testClassifyLinkEdges (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing link edges: multi-construction arrays + ambiguous links..."
+  let s1 := mkDeclI "App.OneScheme" .structure
+  let s2 := mkDeclI "App.TwoScheme" .structure
+  let c1 := mkDeclI "App.c1" .def (head := "App.OneScheme")
+  let c2 := mkDeclI "App.c2" .def (head := "App.TwoScheme")
+  let corrA := mkDeclI "App.correctnessExp" .def .game
+  let multiThm := mkDeclI "App.multi" .theorem .other none
+    #["App.correctnessExp", "App.c1", "App.c2"] #[]
+  let decls := #[s1, s2, c1, c2, corrA, multiThm]
+  result ← test "two constructions → construction array (sorted)"
+    ((clsOf decls "App.multi").map (·.construction) == some #[`App.c1, `App.c2]) result
+  result ← test "two constructions → scheme union (sorted)"
+    ((clsOf decls "App.multi").map (·.scheme) == some #[`App.OneScheme, `App.TwoScheme]) result
+  -- ambiguous atom still carries its construction/scheme links
+  let secA := mkDeclI "App.securityExp" .def .game
+  let ambThm := mkDeclI "App.amb" .theorem .other none
+    #["App.correctnessExp", "App.securityExp", "App.c1"] #[]
+  let dl := #[s1, c1, corrA, secA, ambThm]
+  result ← test "ambiguous atom carries construction link"
+    ((clsOf dl "App.amb").map (fun c => (c.category, c.construction)) == some (.ambiguous, #[`App.c1])) result
+  result ← test "ambiguous atom carries scheme link"
+    ((clsOf dl "App.amb").map (·.scheme) == some #[`App.OneScheme]) result
+  return result
+
+def testClassifyMisuseIgnored (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing kind-incompatible tag is ignored (decl falls through)..."
+  -- @[scheme_def] on a theorem is ignored; the theorem still classifies by naming
+  let thm := mkDeclI "App.correctness" .theorem .other none #[] #[] #["scheme_def"]
+  let (res, diags) := Classify.classify #[thm]
+  let cls := (res.find? (·.1 == `App.correctness)).map (·.2)
+  result ← test "scheme_def on theorem ignored → classified by naming"
+    (cls.map (·.category) == some .correctness) result
+  result ← test "ignored scheme_def is diagnosed" (diags.any (containsSubstring · "scheme_def")) result
   return result
 
 def testViewHelpers (result : TestResult) : IO TestResult := do
@@ -2669,6 +2951,18 @@ def main : IO UInt32 := do
   result ← testCodomainShape result
   result ← testDetectClass result
   result ← testDrift result
+  result ← testClassifySchemes result
+  result ← testClassifyConstructions result
+  result ← testClassifyPromotionWalk result
+  result ← testClassifyWalkTieAndBound result
+  result ← testClassifyLinks result
+  result ← testClassifyConflicts result
+  result ← testClassifyFixpointOrder result
+  result ← testClassifyAttrShapeAndInstance result
+  result ← testClassifyViaWeakest result
+  result ← testClassifyWalkEdges result
+  result ← testClassifyLinkEdges result
+  result ← testClassifyMisuseIgnored result
   result ← testViewHelpers result
   result ← testStubEntryJson result
   result ← testMoleculesOutputJson result

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -943,6 +943,66 @@ def testClassificationJson (result : TestResult) : IO TestResult := do
   result ← test "source.class absent from JSON when none" classAbsent result
   return result
 
+def testCodomainShape (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing classifyCodomain on hand-built Exprs..."
+  let bool := Lean.Expr.const `Bool []
+  let nat := Lean.Expr.const `Nat []
+  let gameHeads := defaultGameHeads
+  -- positive cases
+  let probCompBool := Lean.Expr.app (Lean.Expr.const `ProbComp []) bool
+  let propSort := Lean.Expr.sort Lean.Level.zero
+  let ennreal := Lean.Expr.const `ENNReal []
+  let ckaScheme := Lean.Expr.const `CKAScheme []
+  let forallGame := Lean.Expr.forallE `x nat probCompBool Lean.BinderInfo.default
+  -- multi-argument probabilistic computations (head + final-arg Bool)
+  let oracleCompBool := Lean.Expr.app (Lean.Expr.app (Lean.Expr.const `OracleComp []) (Lean.Expr.const `spec [])) bool
+  let spmfBool := Lean.Expr.app (Lean.Expr.const `SPMF []) bool
+  result ← test "ProbComp Bool → game" (classifyCodomain gameHeads probCompBool == .game) result
+  result ← test "OracleComp spec Bool → game" (classifyCodomain gameHeads oracleCompBool == .game) result
+  result ← test "SPMF Bool → game" (classifyCodomain gameHeads spmfBool == .game) result
+  result ← test "Sort 0 → prop" (classifyCodomain gameHeads propSort == .prop) result
+  result ← test "ENNReal → advantage" (classifyCodomain gameHeads ennreal == .advantage) result
+  result ← test "CKAScheme → other" (classifyCodomain gameHeads ckaScheme == .other) result
+  result ← test "∀ x, ProbComp Bool → game (strips binders)" (classifyCodomain gameHeads forallGame == .game) result
+  -- negative cases: "final arg is Bool" must NOT alone make a game
+  let listBool := Lean.Expr.app (Lean.Expr.const `List []) bool
+  let arrayBool := Lean.Expr.app (Lean.Expr.const `Array []) bool
+  let exceptEBool := Lean.Expr.app (Lean.Expr.app (Lean.Expr.const `Except []) (Lean.Expr.const `ε [])) bool
+  -- a theorem statement (@Eq α a b) has head `Eq`, not a game/advantage
+  let eqStmt := Lean.Expr.app (Lean.Expr.app (Lean.Expr.app (Lean.Expr.const `Eq []) nat) (Lean.Expr.const `a [])) (Lean.Expr.const `b [])
+  result ← test "List Bool → not game (other)" (classifyCodomain gameHeads listBool == .other) result
+  result ← test "Array Bool → not game (other)" (classifyCodomain gameHeads arrayBool == .other) result
+  result ← test "Except ε Bool → not game (other)" (classifyCodomain gameHeads exceptEBool == .other) result
+  result ← test "@Eq α a b (theorem stmt) → other" (classifyCodomain gameHeads eqStmt == .other) result
+
+  IO.println ""
+  IO.println "Testing codomainHeadOf and lastArgIsBool..."
+  let qualifiedScheme := Lean.Expr.const `SecureMessaging.CKA.Defs.CKAScheme []
+  result ← test "head of CKAScheme" (codomainHeadOf ckaScheme == some `CKAScheme) result
+  result ← test "head preserves qualified name" (codomainHeadOf qualifiedScheme == some `SecureMessaging.CKA.Defs.CKAScheme) result
+  result ← test "head through binders is ProbComp" (codomainHeadOf forallGame == some `ProbComp) result
+  result ← test "head of Sort 0 is none" (codomainHeadOf propSort == none) result
+  result ← test "lastArgIsBool ProbComp Bool" (lastArgIsBool probCompBool == true) result
+  result ← test "lastArgIsBool ENNReal is false" (lastArgIsBool ennreal == false) result
+  return result
+
+def testDetectClass (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing security-protocol detection from module names..."
+  result ← test "bare VCVio module → detected" (moduleListIndicatesSecurityProtocol #[`VCVio]) result
+  result ← test "VCVio.* submodule → detected"
+    (moduleListIndicatesSecurityProtocol #[`Mathlib.Data, `VCVio.OracleComp.Basic, `MyProj]) result
+  result ← test "no VCVio → not detected"
+    (!moduleListIndicatesSecurityProtocol #[`Mathlib.Data, `MyProj.Defs]) result
+  result ← test "VCVio prefix-collision (VCVioExtra) → not detected"
+    (!moduleListIndicatesSecurityProtocol #[`VCVioExtra]) result
+  result ← test "empty module list → not detected"
+    (!moduleListIndicatesSecurityProtocol #[]) result
+  return result
+
 def testViewHelpers (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -2559,6 +2619,8 @@ def main : IO UInt32 := do
   result ← testProofsOutputJson result
   result ← testUnifiedAtomJson result
   result ← testClassificationJson result
+  result ← testCodomainShape result
+  result ← testDetectClass result
   result ← testViewHelpers result
   result ← testStubEntryJson result
   result ← testMoleculesOutputJson result

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -293,6 +293,38 @@ Each value contains all atom fields plus verification status and specs:
 | `primary-spec` | string or absent | Code-name of the primary specification theorem for this atom. Absent when none. Determined by precedence: (1) `@[primary_spec]` attribute, (2) known verification-framework attributes (`@[progress]`, `@[pspec]`, `@[step]`), (3) `_spec` suffix match, (4) sole spec inference. |
 | `verification-status` | string or absent | `"transitively-verified"`, `"verified"`, `"unverified"`, `"failed"`, `"trusted"`, or absent if skipped. A declaration is `"verified"` if its own body does not contain `sorry`; it is upgraded to `"transitively-verified"` if, additionally, all its transitive dependencies are verified or trusted (computed via reverse-BFS contamination, skippable with `--skip-enrich`). Declarations that are locally sorry-free but have at least one unverified or failed transitive dependency remain `"verified"`. Axioms, declarations carrying `@[externally_verified]`, and non-theorem declarations from `*External.lean` files (Aeneas trust base) are always `"trusted"`. Theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal status from sorry detection. Declarations without source location (kernel-synthesized) are filtered from output entirely. |
 | `trusted-reason` | string or absent | Present only when `verification-status` is `"trusted"`. Values: `"axiom"` (Lean `axiom` keyword), `"externally_verified"` (declaration tagged `@[externally_verified]` — proof discharged outside Lean), `"external"` (non-theorem declaration in a file ending with `External.lean`). Enables automated trust-base classification. |
+| `classification` | object or absent | Security-protocol classification (absent unless the project class is `security-protocol` and the atom is classified). See *Security-protocol classification* below. |
+
+### Security-protocol classification
+
+For VCVio-based cryptographic projects, probe-lean classifies each declaration into a
+`scheme → construction → {correctness, security}` hierarchy so a consumer can render an
+accordion. This is **additive**: two optional fields appear, and only when a project class is
+detected — non-class projects are byte-identical to before.
+
+- Envelope **`source.class`** — the detected project class (currently `"security-protocol"`).
+  Absent when no class is detected. Resolved by precedence: `extract --class <name>` override >
+  Lake manifest (package-level VCVio dependency) > imported-module signal.
+- Per-atom **`classification`** — an object, **absent** (not `null`) when the atom is unclassified:
+
+  | field | type | meaning |
+  |-------|------|---------|
+  | `category` | string | `scheme`, `construction`, `correctness`, `security`, or `ambiguous` |
+  | `via` | string | how it was determined — `attribute`, `type`, or `naming` (the *weakest* signal in the chain) |
+  | `scheme` | string or array, or absent | code-name(s) of the scheme this atom is about — present when resolvable |
+  | `construction` | string or array, or absent | code-name(s) of the construction a property is about — present when resolvable |
+
+  `category: "ambiguous"` marks an atom recognised as a crypto *property* whose
+  correctness-vs-security axis could not be decided — an equal-depth reachability tie (e.g. a
+  reduction theorem referencing both a correctness assumption and a security advantage),
+  conflicting `@[correctness_spec]`/`@[security_spec]` tags, or a name matching both patterns. It still carries its links; resolve it
+  with an explicit tag. Link fields are **fail-closed**: a string when uniquely resolved, an array
+  when genuinely ambiguous, and absent when unresolvable (links never reference non-emitted atoms,
+  e.g. an imported VCVio scheme). Schemes that are not conventionally named (`*Scheme`/`*Alg`) are
+  not auto-detected and must carry `@[scheme_def]`.
+
+  Full design, signals, and the anchor catalogue:
+  [docs/classification-security-protocol.md](classification-security-protocol.md).
 
 ### `probe-lean/viewify` (molecules)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -72,6 +72,12 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 | `--skip-verify` | | Skip the sorry detection step (graph structure only) |
 | `--from-file <FILE>` | | Use existing build output for sorry detection instead of running lake |
 | `--skip-enrich` | | Skip transitive verification enrichment (no `"transitively-verified"` status) |
+| `--class <NAME>` | | Override the detected project class (e.g. `security-protocol`). Normally auto-detected from a VCVio dependency; this is for manual runs |
+
+For VCVio-based cryptographic projects, `extract` additionally classifies declarations into a
+`scheme → construction → {correctness, security}` hierarchy and emits `source.class` plus a per-atom
+`classification` object (see [SCHEMA.md](SCHEMA.md#security-protocol-classification)). Schemes not
+named `*Scheme`/`*Alg` must carry `@[scheme_def]` (import `ProbeLean.Attrs`) to be detected.
 
 ---
 
@@ -258,7 +264,7 @@ The `extract` command produces a JSON file wrapped in a Schema 2.0 metadata enve
 {
   "schema": "probe-lean/extract",
   "schema-version": "2.0",
-  "tool": { "name": "probe-lean", "version": "0.7.0", "command": "extract" },
+  "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
     "commit": "abc123d",

--- a/docs/classification-security-protocol.md
+++ b/docs/classification-security-protocol.md
@@ -4,8 +4,9 @@ Cryptographic security protocols formalised in Lean on top of
 [VCV-io](https://github.com/Verified-zkEVM/VCV-io) share a recurring shape: an abstract
 **scheme** (a bundle of algorithms), one or more concrete **constructions** that realise it,
 and **correctness** and **security** properties proved about those constructions. probe-lean
-classifies the declarations of such a project into these four categories so that a downstream
-consumer can present them as a `scheme → construction → {correctness, security}` hierarchy.
+classifies the declarations of such a project into these four hierarchy categories so that a
+downstream consumer can present them as a `scheme → construction → {correctness, security}`
+hierarchy. A fifth value, `ambiguous`, marks properties whose category could not be decided (below).
 
 This document describes how that classification is performed and catalogues the symbols and
 patterns it relies on. It is specific to the `security-protocol` class (projects that depend on
@@ -23,8 +24,16 @@ VCVio); other project classes are handled separately.
 Each classified declaration is annotated with its `category`, with `via` — recording **how** the
 category was determined: `attribute`, `type`, or `naming` (defined next) — and, where resolvable,
 with explicit **links** to the construction and scheme it is about (see *Output schema*). A
-declaration that matches none of the four categories — invariant lemmas, helper definitions, game
+declaration that matches none of these categories — invariant lemmas, helper definitions, game
 state records — is left unclassified (no annotation).
+
+A fifth category, **`ambiguous`**, marks a declaration recognised as a crypto *property* whose
+correctness-vs-security axis could not be decided — an equal-depth reachability tie (e.g. a
+reduction theorem touching both a correctness assumption and a security advantage), conflicting
+`@[correctness_spec]`+`@[security_spec]` tags, or an own-name that matches **both** the correctness
+and security naming patterns. It still carries its `scheme`/`construction` links (so it is
+placeable), and is resolved with an explicit tag. It is distinct from *unclassified* (absent),
+which means "not a scheme/construction/property at all".
 
 Classification is applied only to a project's **own** declarations — imported declarations (from
 VCVio, Mathlib, …) never receive a `classification`. They may, however, be *referenced* as
@@ -37,7 +46,11 @@ atoms — otherwise imported anchors such as `SecExp` would be invisible.
 ## How classification works
 
 For each declaration, three signals are consulted in decreasing order of reliability; the first
-that applies wins, and the signal used is recorded in `via`.
+that applies wins, and the signal used is recorded in `via`. (One deliberate exception to the
+"type before naming" order: in the **property-definitions** stage, naming is applied *before* the
+type-reach sub-pass — see *Anchors, the promotion rule, and the walk* — because naming is what
+seeds the project's own games into the anchor set that the type-reach walk then targets. Theorems
+follow the stated `attribute > type > naming` order.)
 
 Classification runs as a **staged pipeline**, because later categories depend on earlier ones:
 
@@ -72,17 +85,20 @@ to pin down anything the heuristics below get wrong or cannot see.
 *registered* by some module the project imports. These attributes belong in
 probe-lean's attribute module (`ProbeLean.Attrs`), following the same pattern as `@[primary_spec]`,
 so a project that wants to tag its declarations imports that module (taking a dependency on
-probe-lean) and adds the tags. probe-lean then detects the tags directly from the built project —
-handle-based from the environment, with a source scan of `@[…]` annotations as a fallback — and
-never edits the project.
+probe-lean) and adds the tags. probe-lean then detects the classification tags **handle-based** from
+the built environment (`TagAttribute.hasTag`) and never edits the project. Because a tag cannot
+compile unless `ProbeLean.Attrs` is imported, the handle check always sees a present tag — so no
+source-scan fallback is needed for classification. (The separate source scan of `@[…]` annotations
+populates the emitted `attributes` field for *other*, third-party attributes; it does not feed the
+classifier.)
 
 So in an **unattended verilib run, attributes only apply to projects that have already adopted
 them**; for every other project, classification falls back to the *type* and *naming* signals.
 
-If a declaration carries **conflicting tags** (e.g. both `@[correctness_spec]` and
-`@[security_spec]`), or a tag whose category is incompatible with its kind (e.g. `@[scheme_def]`
-on a `theorem`), the classifier emits a diagnostic and leaves the declaration unclassified rather
-than guessing.
+If a declaration carries **conflicting tags** (both `@[correctness_spec]` and `@[security_spec]`),
+the classifier emits a diagnostic and classifies it `ambiguous` (below) rather than guessing. A tag
+whose category is incompatible with the declaration's kind (e.g. `@[scheme_def]` on a `theorem`) is
+instead **ignored** with a diagnostic, so the declaration falls through to the type/naming signals.
 
 ### Framework types (`via: type`) — structural inference
 
@@ -172,10 +188,11 @@ through them.
 
 **Walk semantics:** the walk is **bounded** — a fixed maximum depth plus a visited-set; cycles
 and the bound both terminate it, leaving the atom *unclassified* rather than hanging. "Nearest
-anchor wins" means the smallest number of hops; **a tie is left unclassified**. In particular,
-when a statement reaches *both* a correctness and a security anchor at equal distance (e.g.
-`correctness_implies_security`), neither dominates and the atom is left unclassified — resolve
-such cases with `@[correctness_spec]` / `@[security_spec]`.
+anchor wins" means the smallest number of hops; **an equal-depth tie yields `ambiguous`**. In
+particular, when a statement reaches *both* a correctness and a security anchor at equal distance
+(e.g. `correctness_implies_security`), neither dominates and the atom is classified `ambiguous` —
+resolve such cases with `@[correctness_spec]` / `@[security_spec]`. (Reaching *no* anchor — by the
+depth bound or a cycle — leaves the atom unclassified, not `ambiguous`.)
 
 ### Naming conventions (`via: naming`) — last-resort fallback
 
@@ -246,62 +263,71 @@ the last component alone (they would hit unrelated project-local declarations). 
 walk looks for a dependency whose fully-qualified name is one of the catalogued VCVio symbols, or
 a promoted project-local anchor.
 
-The tables below display the **final name component for readability only**; the implementation
-catalogue stores the fully-qualified names (the symbols live in the namespaces of their defining
-structures, e.g. `SymmEncAlg.Complete`, `AsymmEncAlg.Correct`, `PRFScheme.prfAdvantage`). The
-exact fully-qualified enumeration is fixed during implementation against the targeted VCVio
-version — and policed thereafter by the drift diagnostic below.
+The lists below are a snapshot of the enumeration baked into
+[`ProbeLean/Classify/Catalogue.lean`](../ProbeLean/Classify/Catalogue.lean) (**the source of
+truth**), captured against **VCVio commit `ebea2fa`** (the revision the protocol model repos pin).
+The catalogue stores fully-qualified names — the symbols live in their defining structures'
+namespaces (`SymmEncAlg.Complete`, `PRFScheme.prfAdvantage`, …). It is re-verified against the
+targeted VCVio version whenever edited, and policed at runtime by the drift diagnostic.
 
-**Drift diagnostic:** the catalogue names live in probe-lean while VCVio evolves independently, so
-renames upstream silently break individual anchors (this has already happened:
-`preimageFindingAdvantage` was renamed to `programmedPreimageAdvantage`). At classification start,
-probe-lean therefore **resolves every catalogued fully-qualified name against the loaded
-environment and emits a warning for each unresolved anchor** — converting silent drift into a
-visible diagnostic. The warning is informational, not an error: which names exist depends on the
-VCVio version the target project builds against. The catalogue should be re-verified against
-current VCVio whenever it is edited.
+**Drift diagnostic.** VCVio evolves independently, so upstream renames or removals silently break
+individual anchors (e.g. `preimageFindingAdvantage` → `programmedPreimageAdvantage`; neither is
+present at `ebea2fa`). probe-lean checks the catalogue against the loaded environment and emits an
+informational warning — but **family-conditionally**: an anchor is reported only when its parent
+scheme type (e.g. `KEMScheme` for `KEMScheme.IND_CCA_Advantage`) *is* loaded yet the anchor itself
+is absent. Anchors whose family (scheme type) is not imported are silently skipped, so a project
+that uses only a slice of VCVio raises far fewer false alarms. (Top-level anchors like `SecExp`,
+with no scheme-type parent, are likewise not drift-checked. The guard keys on the *immediate*
+parent, so it can still over-report when a scheme's anchors are split across optionally-imported
+submodules — e.g. `AsymmEncAlg` loaded but its `IND_CPA` submodule not; such warnings are
+informational, never errors.)
+
+### VCVio scheme types (construction return-type heads)
+
+`SymmEncAlg`, `AsymmEncAlg`, `AsymmEncAlg.ExplicitCoins`, `PKE_Alg` (an `abbrev` for `AsymmEncAlg`),
+`SignatureAlg`, `KEMScheme`, `PRFScheme`, `PRGScheme`, `CommitmentScheme`, `SigmaProtocol`,
+`OneWay.TrapdoorPermutation`, `GenerableRelation`.
+
+This set has a **single role: construction detection.** A `def`/`abbrev`/`instance` whose
+return-type head is one of these (e.g. `def myEnc : AsymmEncAlg … := …`) is recognised as a
+construction, alongside `def`s returning a project's own scheme. Matching is by exact name on the
+return-type head, so it cannot over-match. These symbols are imported and are **never** classified
+as scheme atoms themselves (only project-own declarations are classified — schemes via
+`@[scheme_def]` or the naming fallback). In practice protocol projects define and return their
+**own** schemes, so this set only matters when a construction returns a VCVio scheme directly.
 
 ### VCVio correctness anchors
 
-| Symbol | Kind |
-|---|---|
-| `Correct`, `Complete` | `def … : Prop` (predicate form) |
-| `CorrectExp`, `CompleteExp` | `def … : m Bool` (game form) |
+`SymmEncAlg.Complete`, `SymmEncAlg.CompleteExp`, `AsymmEncAlg.CorrectExp`,
+`AsymmEncAlg.PerfectlyCorrect`, `SignatureAlg.PerfectlyComplete`, `KEMScheme.CorrectExp`,
+`KEMScheme.PerfectlyCorrect`, `CommitmentScheme.PerfectlyCorrect`, `SigmaProtocol.PerfectlyComplete`,
+`OneWay.TrapdoorPermutation.Correct`.
 
 ### VCVio security anchors
 
-| Symbol | Kind |
-|---|---|
-| `SecExp`, `SecurityExp`, `SecurityGame` | `structure` (experiment) |
-| `advantage`, `bindingAdvantage`, `hidingAdvantage`, `owfAdvantage`, `prfAdvantage`, `prgAdvantage`, `tdpAdvantage`, `programmedPreimageAdvantage`, `collisionFindingAdvantage`, `ddhDistAdvantage`, `ddhGuessAdvantage` | `def` (advantage) |
-
-### VCVio scheme anchors
-
-Algorithm-bundling interfaces defined in VCVio's `CryptoFoundations/`: `SymmEncAlg`,
-`AsymmEncAlg`, `MacAlg`, `KEMScheme`, `DEMScheme`, `SignatureAlg`, `PRFScheme`, `PRGScheme`,
-`CommitmentScheme`, `SigmaProtocol`, `IdenSchemeWithAbort`, `TrapdoorPermutation`,
-`PreimageSampleableFunction`, `GenerableRelation`.
-
-This list has a **single role: construction detection.** It is the set of VCVio scheme types that
-count as a valid **construction return-type head** — so a `def` returning one of them directly
-(e.g. `def myEnc : AsymmEncAlg … := …`) is recognised as a construction, alongside `def`s
-returning a project's own scheme. Matching is by exact name on the return-type head, so it cannot
-over-match.
-
-> **NOTE:** It is **not** a scheme-*classification* input: these symbols are imported and are never classified
-as scheme atoms themselves (only project-own declarations are classified — schemes via
-`@[scheme_def]` or the naming fallback). In practice protocol projects define and return their
-**own** schemes, so this catalogue only matters when a construction returns a VCVio scheme
-directly.
+Experiment types and their advantages: `SecExp` (+`.advantage`), `SecurityExp` (+`.secure`),
+`SecurityGame` (+`.secureAgainst`); `ProbComp.distAdvantage` / `boolDistAdvantage` /
+`guessAdvantage` / `boolBiasAdvantage`; `AsymmEncAlg.IND_CCA_Advantage` and the IND-CPA family
+(`IND_CPA_advantage`, `IND_CPA_signedAdvantageReal`, `IND_CPA_experiment`, `IND_CPA_LR_experiment`,
+`IND_CPA_OneTime_Game`, `IND_CPA_OneTime_Game_ProbComp`, `IND_CPA_OneTime_biasAdvantage`,
+`IND_CPA_OneTime_signedAdvantageReal`), `AsymmEncAlg.ExplicitCoins.OW_CPA_Game` / `OW_CPA_Advantage`;
+`SymmEncAlg.perfectSecrecy` / `perfectSecrecyAt`; `KEMScheme.IND_CCA_Advantage`;
+`PRFScheme.prfAdvantage`; `PRGScheme.prgAdvantage`; `CommitmentScheme.hidingAdvantage` /
+`bindingAdvantage` / `PerfectlyHiding`; `SignatureAlg.unforgeableAdv.advantage`;
+`OneWay.owfAdvantage` / `tdpAdvantage`; `DiffieHellman.ddhGuessAdvantage` / `ddhDistAdvantage`;
+`EntropySmoothing.advantage`; `LearningWithErrors.advantage` / `searchAdvantage`;
+`SigmaProtocol.SpeciallySound` / `SpeciallySoundAt` / `HVZK` / `UniqueResponses`.
 
 ## Class detection
 
-A project is treated as `security-protocol` when it **imports VCVio**, detected from the built
-environment's import graph (with the Lake manifest as a fallback signal — less robust against
-vendoring and renames). Detection is automatic: probe-lean runs unattended in the verilib
-backend, so no flag or configuration is required. An optional `--class` override may be offered
-for manual runs, but verilib never depends on it. When no class is detected, the classification
-stages do not run and the output carries no class fields.
+A project is treated as `security-protocol` when it depends on **VCVio**. The effective class is
+resolved by precedence: a **`--class` override**, then the **Lake manifest** (a package-level
+dependency declaration — filter-independent), then the **imported-module signal** from the built
+environment. Detection is otherwise automatic: probe-lean runs unattended in the verilib backend,
+so no flag is required, and `--class` is only for manual runs. When no class is detected, the
+classification stages do not run and the output carries no class fields. (Note: only the
+`security-protocol` class currently has a classifier — any other detected/overridden class sets
+`source.class` but produces no per-atom `classification`.)
 
 ## Output schema
 
@@ -315,7 +341,7 @@ two new fields are introduced:
 
   | field | meaning | when present |
   |---|---|---|
-  | `category` | `scheme` / `construction` / `correctness` / `security` | always |
+  | `category` | `scheme` / `construction` / `correctness` / `security` / `ambiguous` | always |
   | `via` | the **weakest signal in the classification chain**: `attribute` / `type` / `naming` — a theorem anchored on a promoted anchor inherits that anchor's tier (see *Provenance* above) | always |
   | `scheme` | code-name of the scheme this atom is about | when resolvable (see below) |
   | `construction` | code-name of the construction this property is about | correctness/security atoms, when resolvable |
@@ -336,10 +362,12 @@ under all of them. probe-lean resolves the join while it still has the informati
 - **Scheme-level properties carry `scheme` without `construction`.** Property *definitions*
   (games, predicates, advantage definitions) are generic over constructions — `correctnessExp`
   takes *any* `CKAScheme` — so they resolve no construction; their subject is the scheme itself.
-  They link to the **unique classified scheme among their statement's dependencies**. Likewise, a
-  theorem that resolves no construction but reaches a promoted anchor (e.g. a generic lemma about
-  `securityExp`) inherits that anchor's `scheme`. This distinguishes scheme-level properties from
-  true orphans.
+  They link to the **unique classified scheme among their statement's dependencies** — which
+  distinguishes a scheme-level property (whose statement names the scheme, e.g. `correctnessExp`
+  taking a `CKAScheme`) from a true orphan. (Carrying a *reached* promoted anchor's scheme out of
+  the walk for statements that do not themselves name the scheme is a possible future refinement —
+  see *Reliability and limitations*; the current resolver inspects only the atom's own
+  dependencies.)
 - **Fail-closed:** a link field is **absent** when unresolvable (zero candidates — orphans stay
   visibly orphaned, never fabricated).
 - **JSON types:** each link field is a **string** when uniquely resolved and an **array of
@@ -436,11 +464,12 @@ group-by:
 
 ```
 for each atom with a classification:
-  category == scheme         → create a root
-  category == construction   → place under its `scheme`
-  correctness / security     → place under its `construction`;
-                               if only `scheme` is present, place at scheme level;
-                               if neither, list as unattached
+  category == scheme                     → create a root
+  category == construction               → place under its `scheme`
+  correctness / security / ambiguous     → place under its `construction`;
+                                           if only `scheme` is present, place at scheme level;
+                                           if neither, list as unattached
+                                           (badge `ambiguous` for review / tagging)
 ```
 
 The link-presence pattern encodes the placement directly:
@@ -500,8 +529,8 @@ project adopts the attributes.
   labels such as `:::theorem "…_security" (lean := …)`) could serve as an additional
   classification signal — a possible fourth `via: docs` value. Deferred to a separate issue.
 
-### Open decisions
+### Resolved
 
-- **Schema docs.** `docs/SCHEMA.md` and the test suite must be updated to declare `source.class`
-  and the per-atom `classification` object (including the link fields) as optional fields when
-  this is implemented.
+- **Schema docs.** `docs/SCHEMA.md` now documents `source.class` and the per-atom `classification`
+  object (including the link fields) as optional fields, and the test suite covers their
+  serialization.

--- a/docs/classification-security-protocol.md
+++ b/docs/classification-security-protocol.md
@@ -265,7 +265,9 @@ a promoted project-local anchor.
 
 The lists below are a snapshot of the enumeration baked into
 [`ProbeLean/Classify/Catalogue.lean`](../ProbeLean/Classify/Catalogue.lean) (**the source of
-truth**), captured against **VCVio commit `ebea2fa`** (the revision the protocol model repos pin).
+truth**), enumerated against **VCVio commit `ebea2fa`** (target repos may pin a newer, divergent
+VCVio — e.g. secure-messaging now pins `1e984d2`; the catalogue FQNs were re-verified to resolve
+cleanly there, with no drift warnings).
 The catalogue stores fully-qualified names — the symbols live in their defining structures'
 namespaces (`SymmEncAlg.Complete`, `PRFScheme.prfAdvantage`, …). It is re-verified against the
 targeted VCVio version whenever edited, and policed at runtime by the drift diagnostic.
@@ -434,9 +436,17 @@ envelope field is `sourceClass` in code, serialised to the JSON key `class`.)
     "probe:SecureMessaging.CKA.FromKEM.Security.security_reduces_to_ind_cpa_exists": {
       "display-name": "security_reduces_to_ind_cpa_exists",
       "kind": "theorem",
-      "dependencies": ["probe:SecureMessaging.CKA.Defs.securityExp"],
+      "dependencies": [
+        "probe:SecureMessaging.CKA.Defs.ckaDistAdvantage",
+        "probe:SecureMessaging.CKA.FromKEM.Correctness.decapsDet_eq_some_of_mem_support",
+        "probe:SecureMessaging.CKA.FromKEM.Construction.kemCKA"
+      ],
       "verification-status": "unverified",
-      "classification": { "category": "security", "via": "naming" }
+      "classification": {
+        "category": "ambiguous", "via": "naming",
+        "construction": "probe:SecureMessaging.CKA.FromKEM.Construction.kemCKA",
+        "scheme": "probe:SecureMessaging.CKA.Defs.CKAScheme"
+      }
     },
     "probe:SecureMessaging.CKA.FromDDH.Correctness.reachableInv_init": {
       "display-name": "reachableInv_init",
@@ -451,9 +461,12 @@ Reading the example: `correctnessExp` is a project-own game classified by naming
 an anchor** — generic over constructions, so it carries a `scheme` link only (scheme-level). The
 `correctness` theorem is classified structurally by reaching it, but inherits the anchor's weaker
 tier (`via: naming`), and carries explicit links to its construction and scheme.
-`security_reduces_to_ind_cpa_exists` resolves no unique construction, so its link fields are
-**absent** — a visible orphan, nested nowhere rather than somewhere wrong. `reachableInv_init`
-carries no `classification` key at all — an unclassified helper lemma.
+`security_reduces_to_ind_cpa_exists` is a reduction that reaches a correctness assumption and a
+security advantage at **equal depth**, so its axis cannot be decided and it is classified
+**`ambiguous`** (fail-closed) — its construction/scheme links still resolve, so it stays *placeable*
+but flagged for review. Tag it `@[security_spec]` (or `@[correctness_spec]`) to pin the axis and
+override the tie. `reachableInv_init` carries no `classification` key at all — an unclassified
+helper lemma.
 
 ### Building the accordion from the links
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.7.0"
+version = "0.8.0"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
# Description

Adds **security-protocol classification** to `probe-lean extract`: for VCVio-based crypto projects,
each declaration is classified into a `scheme → construction → {correctness, security}` hierarchy
(plus `ambiguous`) with explicit links, so a consumer can render an accordion. Additive and
fail-closed — non-VCVio projects are unchanged. Implements Phase 1 of #37.

# Changes

- `7e50acc` (1/5) — schema types (`ClassCategory`/`ClassVia`/`Classification`, `source.class`) + the 4 `@[…]` tags; JSON is omit-when-none, links string|array|absent.
- `9a218b0` (2/5) — pure fact extraction (`CodomainShape`, return-head, class tags) in `analyzeDecl`; VCVio class detection + `--class` flag.
- `f474040` (3/5) — VCVio anchor catalogue (FQNs @ `ebea2fa`) + family-conditional drift diagnostic.
- `4cc7be8` (4/5) — the pure classifier: staged pipeline (schemes → constructions → property-defs w/ promotion fixpoint → theorems via bounded walk), fail-closed links, `ambiguous` for ties/conflicts.
- `33c864b` (5/5a) — wire the classifier into `runAnalysisViaLakeEnv` (gated to `security-protocol`); attach `classification` per atom.
- `53d032d` (5/5b) — docs (SCHEMA/USAGE/README/design doc) + version bump `0.8.0`.

# Test run on `secure-messaging` (commit f8d42de)

## Result

166 atoms, **21 classified**, no crash. The full accordion assembled (links resolved):

| category | count | examples (→ links) |
|---|---|---|
| scheme | 2 | `AEADScheme`, `CKAScheme` |
| construction | 2 | `ddhCKA`, `kemCKA.scheme` → `CKAScheme` |
| correctness | 5 | `correctnessExp`; `correctness` → `ddhCKA` / `CKAScheme`; `Correct` → `AEADScheme` |
| security | 11 | `ckaDistAdvantage`, `securityExp`, `guessAdvantage`, … → their scheme |
| ambiguous | 1 | `security_reduces_to_ind_cpa_exists` → `kemCKA.scheme` / `CKAScheme` |

**Non-classified atoms** (145 — all correctly absent: none reach an anchor, none match a naming pattern):

- `ckaSecurityImpl` / `ckaCorrectnessImpl` (`def`) — oracle *machinery* (`QueryImpl …`) fed into the games, not the property itself. The games (`securityExp`/`correctnessExp`) are classified; their impls aren't.
- `GameState`, `RandLeak` (`structure`) — data records, not `*Scheme`/`*Alg`.
- `send`, `recv`, `initA` (`def`/projection) — the scheme's operations, not properties.
- `evalDist_simulateQ_run'_eq_of_bisim`, `keygen_fst` (`theorem`) — distribution/equality plumbing lemmas, reach no anchor.

The one `ambiguous` is a **genuine equal-depth tie**: `security_reduces_to_ind_cpa_exists` references both `kem.PerfectlyCorrect` (a correctness assumption) and `ckaDistAdvantage` (security) — resolvable by tagging `@[security_spec]`.

## Reproducing result

probe-lean's dev toolchain is `v4.28.0-rc1`; to load secure-messaging's oleans you need a build matching its toolchain (`v4.29.0`):

```bash
# in probe-lean (this branch):
echo 'leanprover/lean4:v4.29.0' > lean-toolchain   # temporary — match the target
lake build
git checkout -- lean-toolchain                     # revert after building

# in secure-messaging (already built under v4.29.0):
/path/to/probe-lean/.lake/build/bin/probe-lean extract .
# inspect output json: source.class == "security-protocol"; per-atom "classification" objects
```

# Things to discuss

- **`ambiguous` for reduction theorems.** A reduction that references a correctness *assumption* + a security advantage comes out `ambiguous` (fail-closed). Is tagging `@[security_spec]` the desired resolution, or should we prefer the conclusion's category?
- **verilib consumer** must handle the 5th `category: "ambiguous"` (place via its links, badge "needs a tag").
- **Unconventionally-named schemes** (e.g. PQXDH's `KEM`/`AEAD`/`KDF`) need `@[scheme_def]` to be detected — confirm the tagging expectation.

---
Closes #37
