### PR TITLE
ci(release): add Lean v4.30.0 and v4.31.0 binaries (v0.9.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
           - v4.29.0-rc8
           - v4.29.0
           - v4.30.0-rc2
+          - v4.30.0
+          - v4.31.0
         os:
           - ubuntu-latest
           - macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-18
+
+### Added
+
+- **Pre-built binaries for Lean `v4.30.0` and `v4.31.0`** in the release matrix.
+
 ## [0.9.0] - 2026-06-18
 
 ### Fixed

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.9.0"
+def version : String := "0.9.1"
 
 end ProbeLean

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.9.0"
+version = "0.9.1"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
Adds pre-built probe-lean binaries for the stable Lean **v4.30.0** and **v4.31.0** toolchains to the release matrix.

### Why a patch release
The v4.30.0 matrix entry that was meant for v0.9.0 didn't land before the `v0.9.0` tag was cut (a GitHub webhook lag left a second commit out of the merged PR #44), so the **v0.9.0 release shipped only up to `v4.30.0-rc2`**. This bumps to **0.9.1** so a fresh tag re-runs the full matrix and publishes binaries for every supported version, including v4.30.0 and v4.31.0.

### Changes
- `.github/workflows/release.yml` — matrix now includes `v4.30.0` and `v4.31.0`.
- `lakefile.toml` → 0.9.1; `ProbeLean/Version.lean` regenerated (in sync).
- `CHANGELOG.md` — 0.9.1 entry.

Merging to main auto-tags `v0.9.1` → release builds all matrix versions (× ubuntu/macos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)