### PR TITLE
fix(extract): don't use build targets as a module filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-22
+
+### Fixed
+
+- **`extract` no longer drops every module when `defaultTargets` names a non-library
+  target.** The module filter was derived from auto-detected build targets, but
+  `defaultTargets` may name a `lean_exe` and a `lean_lib` may declare custom `roots` that
+  differ from its name. Treating those as module-name roots filtered out every built module,
+  silently producing `0 atoms`. The library filter is now applied only when the user
+  explicitly passes `--library`; otherwise all of the project's built modules (which is
+  exactly what `.lake/build/lib/lean` contains) are analyzed. As a safety net, `extract` now
+  exits with an actionable error — listing the available top-level module roots — if
+  `--library`/`--module` filters out every built module, instead of writing an empty result.
+
 ## [0.9.1] - 2026-06-18
 
 ### Added

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -98,6 +98,26 @@ def buildClassMap (classifications : Array (Name × Classification)) : Std.HashM
 def moduleInLibraries (m : Lean.Name) (libs : Array String) : Bool :=
   libs.any fun lib => m.toString == lib || m.toString.startsWith (lib ++ ".")
 
+/-- Choose which collected modules to analyze.
+
+    Restricts to `libraries` ONLY when they are explicitly provided (via the
+    `--library` flag). Auto-detected build targets are deliberately NOT used as a
+    module filter here: `defaultTargets` may name a `lean_exe` and a `lean_lib` may
+    declare custom `roots` that differ from its name, so filtering by them can
+    silently drop every module. `.lake/build/lib/lean` already contains only the
+    project's own modules, so the default is to analyze all of them. A single
+    `moduleFilter` (`--module`) further narrows the result by name prefix. -/
+def selectModules (modules : Array Lean.Name) (libraries : Option (Array String))
+    (moduleFilter : Option String) : Array Lean.Name :=
+  let byLib := match libraries with
+    | some libs => modules.filter fun m => moduleInLibraries m libs
+    | none => modules
+  match moduleFilter with
+  | some filter =>
+    let filterName := String.toName filter
+    byLib.filter fun m => m == filterName || m.toString.startsWith (filter ++ ".")
+  | none => byLib
+
 /-- Check if project depends on Mathlib and auto-download the olean cache if missing.
     Without the pre-built cache, `lake build` compiles Mathlib from source (hours). -/
 def ensureMathlibCache (projectPath : System.FilePath)
@@ -198,17 +218,27 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
     IO.eprintln "Error: No modules found in project"
     return 1
 
-  let filteredModules := if !libs.isEmpty then
-    modules.filter fun m => moduleInLibraries m libs
-  else
-    modules
+  let filteredModules := selectModules modules config.libraries config.moduleFilter
 
-  let filteredModules := match config.moduleFilter with
-    | some filter =>
-      let filterName := String.toName filter
-      filteredModules.filter fun m =>
-        m == filterName || m.toString.startsWith (filter ++ ".")
-    | none => filteredModules
+  -- Warn about any explicit `--library` entry that matched no built module, so a
+  -- partial filter (e.g. one good name + one typo, or a name that differs from
+  -- the library's actual module root) isn't applied silently. Note `--library`
+  -- matches by module-name prefix, so it cannot select a library whose `roots`
+  -- differ from its name (use `--module <root>` for those).
+  if let some libs := config.libraries then
+    for lib in libs do
+      if !(modules.any fun m => moduleInLibraries m #[lib]) then
+        IO.eprintln s!"Warning: --library {lib} matched no built module (it is not a module-name root)."
+
+  -- Fail loudly instead of silently writing 0 atoms: if we built modules but
+  -- every one was filtered out, the `--library`/`--module` selection didn't
+  -- match anything that was built.
+  if filteredModules.isEmpty && !modules.isEmpty then
+    IO.eprintln "Error: every project module was filtered out by --library/--module."
+    IO.eprintln s!"  {modules.size} module(s) were built but none matched the requested filter."
+    let roots := (modules.map fun m => (m.toString.splitOn ".").headD m.toString).toList.eraseDups
+    IO.eprintln s!"  Available top-level module roots: {", ".intercalate roots}"
+    return 1
 
   IO.println s!"Analyzing {filteredModules.size} modules..."
 

--- a/ProbeLean/Main.lean
+++ b/ProbeLean/Main.lean
@@ -58,7 +58,7 @@ def extractCmd : Cmd := `[Cli|
     m, module : String; "Filter to specific module prefix"
     "skip-verify"; "Skip the sorry detection step"
     "from-file" : String; "Use existing build output for sorry detection instead of running lake"
-    l, library : String; "Comma-separated list of library names to build (default: auto-detect from lakefile.toml)"
+    l, library : String; "Comma-separated library names to build AND restrict analysis to (by module-name prefix). Omit to build auto-detected targets and analyze all built modules"
     "skip-enrich"; "Skip transitive verification enrichment"
     "class" : String; "Override the detected project class (e.g. security-protocol)"
 

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.9.1"
+def version : String := "0.9.2"
 
 end ProbeLean

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 |--------|-------------|
 | `-o, --output <PATH>` | Output file path (default: `.verilib/probes/lean_<pkg>_<ver>.json`) |
 | `-m, --module <PREFIX>` | Filter to specific module prefix |
-| `-l, --library <LIBS>` | Comma-separated list of library names to build (default: `defaultTargets` from `lakefile.toml`, falling back to all `[[lean_lib]]` entries) |
+| `-l, --library <LIBS>` | Comma-separated library names to build **and** restrict analysis to (by module-name prefix). Omit to build auto-detected targets (`defaultTargets`, falling back to all `[[lean_lib]]` entries) and analyze all built modules |
 | `--skip-verify` | Skip sorry detection (graph structure only) |
 | `--from-file <FILE>` | Use existing build output for sorry detection |
 | `--skip-enrich` | Skip transitive verification enrichment (no `"transitively-verified"` status) |
@@ -194,29 +194,35 @@ works entirely from the **lakefile and the compiled `.olean` build artifacts**.
 Knowing this is the difference between a correct run and a silently incomplete
 one.
 
-**Where the library list comes from** (in priority order):
+**What gets built vs. what gets analyzed** (these are now decoupled):
 
-1. `--library <L1,L2,...>` if you pass it (explicit override).
-2. otherwise `defaultTargets` from `lakefile.toml`.
-3. otherwise all `[[lean_lib]]` entries in `lakefile.toml`.
+- **Build targets** (passed to `lake build`) come from, in priority order:
+  1. `--library <L1,L2,...>` if you pass it.
+  2. otherwise `defaultTargets` from `lakefile.toml`.
+  3. otherwise all `[[lean_lib]]` entries in `lakefile.toml`.
+- **Modules analyzed:** probe-lean collects **every `.olean` under
+  `.lake/build/lib/lean`** (which holds only the project's own modules — deps
+  live under `.lake/packages/`).
+  - **By default (no `--library`)** it analyzes **all** of them. Auto-detected
+    build targets are *not* used as an analysis filter, because `defaultTargets`
+    may name a `lean_exe` and a `lean_lib` may declare custom `roots` that differ
+    from its name — using either as a module filter would silently drop every
+    module.
+  - **With `--library A,B`** it keeps only modules belonging to those library
+    roots (a module `A.B` belongs to library `A`).
 
-probe-lean then runs `lake build <those libs>`, collects **every `.olean` under
-`.lake/build/lib/lean`**, keeps the modules that **belong to the selected
-libraries** (a module `A.B` belongs to library `A`), optionally narrows further
-with `--module <prefix>`, and imports all surviving modules into a **single Lean
-environment** before atomizing.
+Then `--module <prefix>` optionally narrows further, and all surviving modules
+are imported into a **single Lean environment** before atomizing.
 
 **Assumptions this bakes in — and how they bite:**
 
-- **A library you want extracted must be *selected*, not merely *built*.** If
-  library `A` is a default target and depends on library `B`, `lake build A`
-  compiles `B` too — but `B`'s modules are filtered out of the output because
-  `B` isn't in the selected set. **If a needed library is only a dependency of a
-  default target, list it in `defaultTargets` or pass it via `--library`.**
-  (Example: a project that moves Aeneas-generated code into its own `lean_lib`
-  for linting must still add that lib to `defaultTargets`, or its atoms vanish
-  from the output with no error.)
-- **All selected modules must be mutually importable.** Two modules may not
+- **`--library` matches by module-name prefix.** It can only select a library
+  whose module root equals its name. A `lean_lib` whose `roots` differ from its
+  name cannot be selected by `--library`; use `--module <root>` for those (or omit
+  `--library` to analyze everything). probe-lean warns about any `--library`
+  entry that matched no built module, and errors out if filters remove *every*
+  module rather than writing an empty result.
+- **All analyzed modules must be mutually importable.** Two modules may not
   declare the same fully-qualified name, or the import aborts with
   `environment already contains '<name>' from <module>`.
 - **Module discovery trusts the build directory, not git.** Because it scans
@@ -225,8 +231,8 @@ environment** before atomizing.
   symbol is the most common cause of the duplicate-declaration import failure
   above. When in doubt after a refactor, `lake clean` first.
 
-> Improving the first and third points (auto-including the dependency closure of
-> the selected libraries, and ignoring stale orphan oleans) is tracked in
+> Resolving libraries to their actual Lake module roots (so `--library` works for
+> libraries with custom `roots`) and ignoring stale orphan oleans is tracked in
 > [#40](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/40).
 
 ## Testing

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -2564,6 +2564,52 @@ def testParseDefaultTargets (result : TestResult) : IO TestResult := do
   try IO.FS.removeDirAll tmpBase catch _ => pure ()
   return result
 
+def testSelectModules (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing selectModules (module filtering)..."
+
+  -- A typical layout: a `MyLib` library, its submodule, an executable root
+  -- `Main`, and a test module whose library declares a custom root.
+  let modules : Array Lean.Name :=
+    #["MyLib".toName, "MyLib.Core.Widget".toName, "Main".toName, "Tests.Helper".toName]
+
+  -- No explicit --library: analyze every collected module. This is the
+  -- regression for the bug where a non-library build target (a `lean_exe` name
+  -- from `defaultTargets`) was used as a filter and dropped all modules.
+  let allMods := selectModules modules none none
+  result ← test "no library filter: keeps all modules" (allMods.size == 4) result
+
+  -- Explicit --library matching the library's module root keeps only its modules.
+  let libMods := selectModules modules (some #["MyLib"]) none
+  result ← test "library MyLib: keeps lib + submodule" (libMods.size == 2) result
+  result ← test "library MyLib: keeps MyLib" (libMods.contains "MyLib".toName) result
+  result ← test "library MyLib: keeps submodule" (libMods.contains "MyLib.Core.Widget".toName) result
+  result ← test "library MyLib: drops Main" (!libMods.contains "Main".toName) result
+
+  -- A filter that matches nothing yields empty (the caller turns this into a
+  -- loud error rather than silently writing 0 atoms). Case-sensitive: a
+  -- lowercase executable name matches no `MyLib.*` module.
+  let exeNameFilter := selectModules modules (some #["mylib"]) none
+  result ← test "library mylib (exe name): matches nothing" (exeNameFilter.isEmpty) result
+
+  -- --module narrows by name prefix on top of the (default) all-modules set.
+  let coreOnly := selectModules modules none (some "MyLib.Core")
+  result ← test "module filter MyLib.Core: keeps only submodule" (coreOnly.size == 1) result
+  result ← test "module filter MyLib.Core: is the widget module"
+    (coreOnly[0]? == some "MyLib.Core.Widget".toName) result
+
+  -- Documented limitation (tracked in #40): `--library` matches by module-name
+  -- prefix, so a library whose `roots` differ from its name cannot be selected by
+  -- name. `--module` is the escape hatch for those.
+  let byLibName := selectModules modules (some #["HelperSuite"]) none
+  result ← test "library by name with custom roots: does not match (known limitation)"
+    (byLibName.isEmpty) result
+  let byModuleRoot := selectModules modules none (some "Tests.Helper")
+  result ← test "module filter reaches custom-root module" (byModuleRoot.size == 1) result
+
+  return result
+
 def testLeanInvariants (result : TestResult) : IO TestResult := do
   let mut result := result
 
@@ -3147,6 +3193,7 @@ def main : IO UInt32 := do
   result ← testLeanInvariants result
   result ← testParseLeanLibs result
   result ← testParseDefaultTargets result
+  result ← testSelectModules result
   result ← testVersionConsistency result
   result ← testCacheValidity result
   result ← testCheckFilesSkipsDotDirs result

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -68,7 +68,7 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 |------|-------|-------------|
 | `--output <PATH>` | `-o` | Output file path (default: `.verilib/probes/lean_<pkg>_<ver>.json`) |
 | `--module <PREFIX>` | `-m` | Filter to specific module prefix |
-| `--library <LIBS>` | `-l` | Comma-separated list of library names to build (default: `defaultTargets` from `lakefile.toml`, falling back to all `[[lean_lib]]` entries) |
+| `--library <LIBS>` | `-l` | Comma-separated list of library names to build **and** restrict analysis to (modules are kept only if they belong to one of these library roots). When omitted, the build uses `defaultTargets` from `lakefile.toml` (falling back to all `[[lean_lib]]` entries) and **all** of the project's built modules are analyzed — auto-detected targets are not used as a module filter, since `defaultTargets` may name a `lean_exe` or a library may declare custom `roots`. |
 | `--skip-verify` | | Skip the sorry detection step (graph structure only) |
 | `--from-file <FILE>` | | Use existing build output for sorry detection instead of running lake |
 | `--skip-enrich` | | Skip transitive verification enrichment (no `"transitively-verified"` status) |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.9.1"
+version = "0.9.2"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
# Issue

`probe-lean extract` found **0 modules / 0 atoms** on projects whose `defaultTargets` names a non-library target. On [LeanCert](https://github.com/alerad/leancert) — `defaultTargets = ["leancert"]` (a `lean_exe`) — all 171 built modules were silently dropped and an empty result was written:

```
Analyzing 0 modules...
Found 0 atoms
Wrote 0 unified atoms to ./.verilib/probes/lean_LeanCert_0.1.0.json
```

# Root cause

`getLeanLibs` returns `defaultTargets` verbatim, and that list was reused as a **module-name-prefix filter** (`moduleInLibraries`). But build-target names are not module roots:

- `defaultTargets` may name a `lean_exe` (`leancert`), whose name matches no module (modules are `LeanCert.*`; the match is also case-sensitive).
- a `lean_lib` may declare custom `roots` that differ from its name.

So the filter removed every module. The `if modules.isEmpty` guard didn't fire because the emptiness was introduced *after* collection, by the filter.

# Fix

- The library filter is applied **only when the user explicitly passes `--library`**. Otherwise all built modules are analyzed — `.lake/build/lib/lean` already contains only the project's own modules (dependencies live under `.lake/packages/`). Build-target detection (`getLeanLibs`) is unchanged, so `lake build` still builds the right targets.
- **Fail loudly** instead of writing 0 atoms: if `--library`/`--module` filters out every built module, `extract` errors and lists the available top-level module roots.
- **Warn** about any `--library` entry that matched no built module (partial/typo filters).
- New pure helper `selectModules` with unit tests; README/USAGE/CLI-help updated; version bumped to `0.9.2`.

Verified behavior-preserving on `curve25519-dalek-lean-verify` (whose `defaultTargets` matches a real `lean_lib`): v0.9.1 and v0.9.2 produce byte-for-byte identical atom data (219 modules, 2039 atoms).

# How to test

These steps reproduce the before/after on [LeanCert](https://github.com/alerad/leancert), whose toolchain is `v4.31.0`. Run all `extract` commands from inside the cloned repo.

### 1. Clone LeanCert and download its Mathlib cache

```bash
git clone https://github.com/alerad/leancert
cd leancert
lake exe cache get      # pulls prebuilt Mathlib .oleans (toolchain v4.31.0)
```

### 2. Install probe-lean v0.9.1 (before the fix)

v0.9.1 is the current release. The installer auto-detects LeanCert's `v4.31.0`
toolchain and downloads the matching prebuilt binary:

```bash
curl -sSfL https://raw.githubusercontent.com/Beneficial-AI-Foundation/probe-lean/main/tools/bash/install.sh \
  | bash -s -- --from-project .
# installs ~/.local/bin/probe-lean-v4.31.0 and symlinks ~/.local/bin/probe-lean
cp ~/.local/bin/probe-lean-v4.31.0 ~/.local/bin/probe-lean-0.9.1   # keep it aside before installing 0.9.2
~/.local/bin/probe-lean-0.9.1 --version   # 0.9.1
```

Run it:

```bash
~/.local/bin/probe-lean-0.9.1 extract .
```

Buggy output — every module is filtered out:

```
Analyzing 0 modules...
Found 0 atoms
Wrote 0 unified atoms to ./.verilib/probes/lean_LeanCert_0.1.0.json
```

### 3. Install probe-lean v0.9.2 (this PR)

v0.9.2 is not released yet, so build it from this branch. The probe-lean binary
**must** be built with the same Lean toolchain as the target project (`v4.31.0`),
or olean import fails with `incompatible header`:

```bash
git clone -b fix/library-filter-drops-all-modules \
  https://github.com/Beneficial-AI-Foundation/probe-lean.git probe-lean-0.9.2
cd probe-lean-0.9.2
echo "leanprover/lean4:v4.31.0" > lean-toolchain   # match LeanCert's toolchain
lake build
cp .lake/build/bin/probe-lean ~/.local/bin/probe-lean-0.9.2
~/.local/bin/probe-lean-0.9.2 --version   # 0.9.2
cd -                                       # back to the leancert checkout
```

(After v0.9.2 is released, the same `install.sh --from-project .` step from §2
will fetch the prebuilt v0.9.2 binary instead of building from source.)

Run it:

```bash
~/.local/bin/probe-lean-0.9.2 extract .
```

Fixed output — all modules are analyzed:

```
Analyzing 171 modules...
Found 4110 declarations
Found 4110 atoms
Wrote 4104 unified atoms to ./.verilib/probes/lean_LeanCert_0.1.0.json
```

Closes #47
