### PR TITLE
feat(installer): recursively auto-detect lean-toolchain for --from-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- **Installer `--from-project` gives actionable errors for bad paths.** Both
-  `tools/bash/install.sh` and `tools/python/install.py` previously emitted the same terse
-  `Error: lean-toolchain not found at <path>/lean-toolchain` whether the path didn't exist,
-  was a file, or was a directory without a `lean-toolchain`. They now distinguish these cases
-  and, when the given directory has no `lean-toolchain` but a subdirectory does (common in
-  monorepos where the Lean project lives in a subfolder, e.g. `cedar-spec/cedar-lean`),
-  suggest the correct `--from-project` path.
+- **Installer `--from-project` auto-detects the toolchain recursively.** When the given
+  directory has no top-level `lean-toolchain` (common in monorepos where the Lean package
+  lives in a subfolder, e.g. `cedar-spec/cedar-lean`), both `tools/bash/install.sh` and
+  `tools/python/install.py` now search recursively (excluding `.lake`) and use the toolchain
+  they find, so the installer works unattended when handed a repo root. If the found files
+  disagree on the version, it errors and lists them rather than guessing. Bad paths
+  (nonexistent, a file, or a directory with no toolchain anywhere) now give distinct,
+  actionable errors instead of the previous terse `lean-toolchain not found`.
 
 ## [0.9.2] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installer `--from-project` gives actionable errors for bad paths.** Both
+  `tools/bash/install.sh` and `tools/python/install.py` previously emitted the same terse
+  `Error: lean-toolchain not found at <path>/lean-toolchain` whether the path didn't exist,
+  was a file, or was a directory without a `lean-toolchain`. They now distinguish these cases
+  and, when the given directory has no `lean-toolchain` but a subdirectory does (common in
+  monorepos where the Lean project lives in a subfolder, e.g. `cedar-spec/cedar-lean`),
+  suggest the correct `--from-project` path.
+
 ## [0.9.2] - 2026-06-22
 
 ### Fixed

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,7 +42,7 @@ probe-lean --version
 
 | Flag | Description |
 |------|-------------|
-| `--from-project <path>` | Auto-detect the Lean version from the target project's `lean-toolchain`. Point this at the directory holding `lakefile.toml`/`lakefile.lean` and `lean-toolchain` — in monorepos the Lean project is often a subfolder (e.g. `cedar-spec/cedar-lean`). If the path has no `lean-toolchain` but a subdirectory does, the installer suggests the right path. |
+| `--from-project <path>` | Auto-detect the Lean version from the target project's `lean-toolchain`. If `<path>` has no top-level `lean-toolchain`, the installer searches recursively (excluding `.lake`) and uses the toolchain it finds — so pointing at a monorepo root works even when the Lean package is a subfolder (e.g. `cedar-spec/cedar-lean`). If multiple toolchains disagree on the version, it errors and lists them; pass `--lean-version` to disambiguate. |
 | `--lean-version <ver>` | Explicit Lean version (e.g., `v4.28.0`) |
 | `--force` | Reinstall even if the version is already installed |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,7 +42,7 @@ probe-lean --version
 
 | Flag | Description |
 |------|-------------|
-| `--from-project <path>` | Auto-detect the Lean version from the target project's `lean-toolchain` |
+| `--from-project <path>` | Auto-detect the Lean version from the target project's `lean-toolchain`. Point this at the directory holding `lakefile.toml`/`lakefile.lean` and `lean-toolchain` — in monorepos the Lean project is often a subfolder (e.g. `cedar-spec/cedar-lean`). If the path has no `lean-toolchain` but a subdirectory does, the installer suggests the right path. |
 | `--lean-version <ver>` | Explicit Lean version (e.g., `v4.28.0`) |
 | `--force` | Reinstall even if the version is already installed |
 

--- a/tests/test_install_helpers.sh
+++ b/tests/test_install_helpers.sh
@@ -29,21 +29,35 @@ detect_version_from_project() {
         echo "Error: --from-project path is not a directory: $project_path" >&2
         return 1
     fi
-    local toolchain_file="$project_path/lean-toolchain"
-    if [ ! -f "$toolchain_file" ]; then
-        echo "Error: lean-toolchain not found in $project_path" >&2
-        local found
-        found=$(find -L "$project_path" -maxdepth 2 -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | head -5)
-        if [ -n "$found" ]; then
-            echo "       Found lean-toolchain in a subdirectory. Did you mean:" >&2
-            while IFS= read -r f; do
-                echo "         --from-project $(dirname "$f")" >&2
-            done <<< "$found"
-        fi
-        return 1
-    fi
     local contents
-    contents=$(cat "$toolchain_file" | tr -d '[:space:]')
+    if [ -f "$project_path/lean-toolchain" ]; then
+        contents=$(cat "$project_path/lean-toolchain")
+    else
+        local found
+        found=$(find -L "$project_path" -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | sort)
+        if [ -z "$found" ]; then
+            echo "Error: no lean-toolchain found anywhere under $project_path" >&2
+            return 1
+        fi
+        local versions
+        versions=$(while IFS= read -r f; do
+            local c
+            c=$(cat "$f" | tr -d '[:space:]')
+            echo "${c##*:}"
+        done <<< "$found" | sort -u)
+        if [ "$(echo "$versions" | wc -l)" -gt 1 ]; then
+            echo "Error: lean-toolchain files with differing versions under $project_path:" >&2
+            while IFS= read -r f; do
+                echo "         $f -> $(cat "$f" | tr -d '[:space:]')" >&2
+            done <<< "$found"
+            return 1
+        fi
+        local chosen
+        chosen=$(echo "$found" | head -1)
+        echo "Note: no lean-toolchain at $project_path; detected from $chosen" >&2
+        contents=$(cat "$chosen")
+    fi
+    contents=$(echo "$contents" | tr -d '[:space:]')
     if [[ "$contents" == *":"* ]]; then
         echo "${contents##*:}"
     else
@@ -111,17 +125,38 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# Test: directory without toolchain but with one in a subdirectory suggests it
+# Test: directory without top-level toolchain auto-detects from a subdirectory
 mkdir -p "$TMPDIR/monorepo/lean-pkg"
 echo "leanprover/lean4:v4.30.0" > "$TMPDIR/monorepo/lean-pkg/lean-toolchain"
-ERR=$(detect_version_from_project "$TMPDIR/monorepo" 2>&1 || true)
-if [[ "$ERR" == *"Did you mean"* && "$ERR" == *"$TMPDIR/monorepo/lean-pkg"* ]]; then
-    echo "  PASS: suggests subdirectory containing lean-toolchain"
+RESULT=$(detect_version_from_project "$TMPDIR/monorepo" 2>/dev/null)
+assert_eq "auto-detect from subdirectory" "v4.30.0" "$RESULT"
+
+# Test: multiple subdirs with the SAME version resolve to that version
+mkdir -p "$TMPDIR/mono2/a" "$TMPDIR/mono2/b"
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/mono2/a/lean-toolchain"
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/mono2/b/lean-toolchain"
+RESULT=$(detect_version_from_project "$TMPDIR/mono2" 2>/dev/null)
+assert_eq "same version across subdirs" "v4.30.0" "$RESULT"
+
+# Test: multiple subdirs with DIFFERING versions error (ambiguous, no auto-pick)
+mkdir -p "$TMPDIR/mono3/a" "$TMPDIR/mono3/b"
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/mono3/a/lean-toolchain"
+echo "leanprover/lean4:v4.31.0" > "$TMPDIR/mono3/b/lean-toolchain"
+ERR=$(detect_version_from_project "$TMPDIR/mono3" 2>&1 || true)
+if [[ "$ERR" == *"differing versions"* ]]; then
+    echo "  PASS: differing subdir versions error as ambiguous"
     PASS=$((PASS + 1))
 else
-    echo "  FAIL: subdirectory suggestion (got '$ERR')"
+    echo "  FAIL: ambiguous versions (got '$ERR')"
     FAIL=$((FAIL + 1))
 fi
+
+# Test: .lake dependency toolchains are excluded from the search
+mkdir -p "$TMPDIR/mono4/.lake/packages/dep" "$TMPDIR/mono4/pkg"
+echo "leanprover/lean4:v4.99.0" > "$TMPDIR/mono4/.lake/packages/dep/lean-toolchain"
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/mono4/pkg/lean-toolchain"
+RESULT=$(detect_version_from_project "$TMPDIR/mono4" 2>/dev/null)
+assert_eq "ignores .lake dependency toolchains" "v4.30.0" "$RESULT"
 
 echo ""
 echo "=== Testing platform detection ==="

--- a/tests/test_install_helpers.sh
+++ b/tests/test_install_helpers.sh
@@ -21,9 +21,25 @@ assert_eq() {
 # We extract it by sourcing a subset
 detect_version_from_project() {
     local project_path=$1
+    if [ ! -e "$project_path" ]; then
+        echo "Error: --from-project path does not exist: $project_path" >&2
+        return 1
+    fi
+    if [ ! -d "$project_path" ]; then
+        echo "Error: --from-project path is not a directory: $project_path" >&2
+        return 1
+    fi
     local toolchain_file="$project_path/lean-toolchain"
     if [ ! -f "$toolchain_file" ]; then
-        echo "Error: lean-toolchain not found at $toolchain_file" >&2
+        echo "Error: lean-toolchain not found in $project_path" >&2
+        local found
+        found=$(find -L "$project_path" -maxdepth 2 -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | head -5)
+        if [ -n "$found" ]; then
+            echo "       Found lean-toolchain in a subdirectory. Did you mean:" >&2
+            while IFS= read -r f; do
+                echo "         --from-project $(dirname "$f")" >&2
+            done <<< "$found"
+        fi
         return 1
     fi
     local contents
@@ -72,6 +88,39 @@ if detect_version_from_project "$TMPDIR/proj5" 2>/dev/null; then
 else
     echo "  PASS: missing file returns error"
     PASS=$((PASS + 1))
+fi
+
+# Test: nonexistent path errors with a distinct message
+ERR=$(detect_version_from_project "$TMPDIR/does-not-exist" 2>&1 || true)
+if [[ "$ERR" == *"path does not exist"* ]]; then
+    echo "  PASS: nonexistent path reports 'does not exist'"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: nonexistent path message (got '$ERR')"
+    FAIL=$((FAIL + 1))
+fi
+
+# Test: path is a file, not a directory
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/afile"
+ERR=$(detect_version_from_project "$TMPDIR/afile" 2>&1 || true)
+if [[ "$ERR" == *"not a directory"* ]]; then
+    echo "  PASS: file path reports 'not a directory'"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: file path message (got '$ERR')"
+    FAIL=$((FAIL + 1))
+fi
+
+# Test: directory without toolchain but with one in a subdirectory suggests it
+mkdir -p "$TMPDIR/monorepo/lean-pkg"
+echo "leanprover/lean4:v4.30.0" > "$TMPDIR/monorepo/lean-pkg/lean-toolchain"
+ERR=$(detect_version_from_project "$TMPDIR/monorepo" 2>&1 || true)
+if [[ "$ERR" == *"Did you mean"* && "$ERR" == *"$TMPDIR/monorepo/lean-pkg"* ]]; then
+    echo "  PASS: suggests subdirectory containing lean-toolchain"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: subdirectory suggestion (got '$ERR')"
+    FAIL=$((FAIL + 1))
 fi
 
 echo ""

--- a/tools/bash/install.sh
+++ b/tools/bash/install.sh
@@ -34,9 +34,29 @@ EOF
 
 detect_version_from_project() {
     local project_path=$1
+    if [ ! -e "$project_path" ]; then
+        echo "Error: --from-project path does not exist: $project_path" >&2
+        echo "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)." >&2
+        exit 1
+    fi
+    if [ ! -d "$project_path" ]; then
+        echo "Error: --from-project path is not a directory: $project_path" >&2
+        echo "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)." >&2
+        exit 1
+    fi
     local toolchain_file="$project_path/lean-toolchain"
     if [ ! -f "$toolchain_file" ]; then
-        echo "Error: lean-toolchain not found at $toolchain_file" >&2
+        echo "Error: lean-toolchain not found in $project_path" >&2
+        local found
+        found=$(find -L "$project_path" -maxdepth 2 -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | head -5)
+        if [ -n "$found" ]; then
+            echo "       Found lean-toolchain in a subdirectory. Did you mean:" >&2
+            while IFS= read -r f; do
+                echo "         --from-project $(dirname "$f")" >&2
+            done <<< "$found"
+        else
+            echo "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)." >&2
+        fi
         exit 1
     fi
     local contents

--- a/tools/bash/install.sh
+++ b/tools/bash/install.sh
@@ -44,23 +44,42 @@ detect_version_from_project() {
         echo "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)." >&2
         exit 1
     fi
-    local toolchain_file="$project_path/lean-toolchain"
-    if [ ! -f "$toolchain_file" ]; then
-        echo "Error: lean-toolchain not found in $project_path" >&2
-        local found
-        found=$(find -L "$project_path" -maxdepth 2 -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | head -5)
-        if [ -n "$found" ]; then
-            echo "       Found lean-toolchain in a subdirectory. Did you mean:" >&2
-            while IFS= read -r f; do
-                echo "         --from-project $(dirname "$f")" >&2
-            done <<< "$found"
-        else
-            echo "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)." >&2
-        fi
-        exit 1
-    fi
     local contents
-    contents=$(cat "$toolchain_file" | tr -d '[:space:]')
+    if [ -f "$project_path/lean-toolchain" ]; then
+        contents=$(cat "$project_path/lean-toolchain")
+    else
+        # No toolchain at the top level. The installer is run automatically on a
+        # project path with no chance for the user to retry, so search recursively
+        # (the Lean package often lives in a subdirectory, e.g. cedar-spec/cedar-lean).
+        # Exclude .lake so dependencies' toolchains don't pollute the search.
+        local found
+        found=$(find -L "$project_path" -name lean-toolchain -not -path '*/.lake/*' 2>/dev/null | sort)
+        if [ -z "$found" ]; then
+            echo "Error: no lean-toolchain found anywhere under $project_path" >&2
+            echo "       Pass an explicit version with --lean-version <ver>." >&2
+            exit 1
+        fi
+        # Collect the distinct versions across all toolchain files found.
+        local versions
+        versions=$(while IFS= read -r f; do
+            local c
+            c=$(cat "$f" | tr -d '[:space:]')
+            echo "${c##*:}"
+        done <<< "$found" | sort -u)
+        if [ "$(echo "$versions" | wc -l)" -gt 1 ]; then
+            echo "Error: lean-toolchain files with differing versions under $project_path:" >&2
+            while IFS= read -r f; do
+                echo "         $f -> $(cat "$f" | tr -d '[:space:]')" >&2
+            done <<< "$found"
+            echo "       Point --from-project at the specific Lean package, or use --lean-version <ver>." >&2
+            exit 1
+        fi
+        local chosen
+        chosen=$(echo "$found" | head -1)
+        echo "Note: no lean-toolchain at $project_path; detected from $chosen" >&2
+        contents=$(cat "$chosen")
+    fi
+    contents=$(echo "$contents" | tr -d '[:space:]')
     # Extract version after ":" (e.g., leanprover/lean4:v4.28.0-rc1 -> v4.28.0-rc1)
     if [[ "$contents" == *":"* ]]; then
         echo "${contents##*:}"

--- a/tools/python/install.py
+++ b/tools/python/install.py
@@ -31,9 +31,28 @@ GITHUB_REPO = "Beneficial-AI-Foundation/probe-lean"
 
 def detect_version_from_project(project_path: Path) -> str:
     """Read lean-toolchain from a target project and extract the version."""
+    hint = "       Point it at a Lean project directory (the one containing lakefile.toml/lakefile.lean and lean-toolchain)."
+    if not project_path.exists():
+        print(f"Error: --from-project path does not exist: {project_path}", file=sys.stderr)
+        print(hint, file=sys.stderr)
+        sys.exit(1)
+    if not project_path.is_dir():
+        print(f"Error: --from-project path is not a directory: {project_path}", file=sys.stderr)
+        print(hint, file=sys.stderr)
+        sys.exit(1)
     toolchain_file = project_path / "lean-toolchain"
     if not toolchain_file.exists():
-        print(f"Error: lean-toolchain not found at {toolchain_file}", file=sys.stderr)
+        print(f"Error: lean-toolchain not found in {project_path}", file=sys.stderr)
+        found = [
+            p for p in sorted(project_path.glob("*/lean-toolchain"))
+            if ".lake" not in p.parts
+        ][:5]
+        if found:
+            print("       Found lean-toolchain in a subdirectory. Did you mean:", file=sys.stderr)
+            for p in found:
+                print(f"         --from-project {p.parent}", file=sys.stderr)
+        else:
+            print(hint, file=sys.stderr)
         sys.exit(1)
     contents = toolchain_file.read_text().strip()
     if ":" in contents:

--- a/tools/python/install.py
+++ b/tools/python/install.py
@@ -41,20 +41,30 @@ def detect_version_from_project(project_path: Path) -> str:
         print(hint, file=sys.stderr)
         sys.exit(1)
     toolchain_file = project_path / "lean-toolchain"
-    if not toolchain_file.exists():
-        print(f"Error: lean-toolchain not found in {project_path}", file=sys.stderr)
-        found = [
-            p for p in sorted(project_path.glob("*/lean-toolchain"))
-            if ".lake" not in p.parts
-        ][:5]
-        if found:
-            print("       Found lean-toolchain in a subdirectory. Did you mean:", file=sys.stderr)
+    if toolchain_file.exists():
+        contents = toolchain_file.read_text().strip()
+    else:
+        # No toolchain at the top level. The installer is run automatically on a
+        # project path with no chance for the user to retry, so search recursively
+        # (the Lean package often lives in a subdirectory, e.g. cedar-spec/cedar-lean).
+        # Exclude .lake so dependencies' toolchains don't pollute the search.
+        found = sorted(
+            p for p in project_path.rglob("lean-toolchain") if ".lake" not in p.parts
+        )
+        if not found:
+            print(f"Error: no lean-toolchain found anywhere under {project_path}", file=sys.stderr)
+            print("       Pass an explicit version with --lean-version <ver>.", file=sys.stderr)
+            sys.exit(1)
+        versions = sorted({p.read_text().strip().split(":")[-1] for p in found})
+        if len(versions) > 1:
+            print(f"Error: lean-toolchain files with differing versions under {project_path}:", file=sys.stderr)
             for p in found:
-                print(f"         --from-project {p.parent}", file=sys.stderr)
-        else:
-            print(hint, file=sys.stderr)
-        sys.exit(1)
-    contents = toolchain_file.read_text().strip()
+                print(f"         {p} -> {p.read_text().strip()}", file=sys.stderr)
+            print("       Point --from-project at the specific Lean package, or use --lean-version <ver>.", file=sys.stderr)
+            sys.exit(1)
+        chosen = found[0]
+        print(f"Note: no lean-toolchain at {project_path}; detected from {chosen}", file=sys.stderr)
+        contents = chosen.read_text().strip()
     if ":" in contents:
         return contents.split(":")[-1]
     return contents


### PR DESCRIPTION
Closes #49

## Context

`--from-project` is run automatically by a pipeline given a project path — there's no human to read a hint and re-run. A colleague hit `Error: lean-toolchain not found ...` against cedar-spec, whose Lean package lives in a subfolder (`cedar-spec/cedar-lean`).

## Change

When `<path>` has no top-level `lean-toolchain`, both `tools/bash/install.sh` and `tools/python/install.py` now:

1. search recursively (excluding `.lake`, so dependency toolchains don't pollute) and use the toolchain found — the installer resolves the version unattended;
2. if multiple toolchain files disagree on the version, error and list them rather than guessing;
3. otherwise (nonexistent path, a file, or no toolchain anywhere) give a distinct, actionable error.

A top-level `lean-toolchain` still takes precedence and short-circuits the search.

## Tests

`tests/test_install_helpers.sh` (12 cases, all pass): version parsing, nonexistent/file paths, recursive auto-detect from a subdirectory, same-version-across-subdirs, ambiguous differing versions, and `.lake` exclusion. Verified against the real bash and python installers on synthetic monorepo layouts.

## Docs

CHANGELOG `[Unreleased]` entry and an updated `--from-project` description in `docs/USAGE.md`.

Note: this only touches the installer — `probe-lean extract` never emitted this error.