### PR TITLE
fix(extract): ignore orphan oleans by filtering on source existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-06-24
+
+### Fixed
+
+- **`extract` no longer crashes on orphan `.olean` files.** Module discovery scanned
+  `.lake/build/lib/lean` for every `.olean` on disk and imported them all into one
+  environment. Lake never garbage-collects oleans, so after a `.lean` file was renamed or
+  deleted its stale "orphan" olean lingered and — when it re-declared a name now owned by
+  the module that replaced it — made the import abort with `environment already contains
+  '...'` (issue #51). `getProjectModules` now keeps only modules with a backing `.lean`
+  source, resolving each module against `"."` plus every `srcDir` declared in
+  `lakefile.toml`. The check is conservative (a module is dropped only when *no* source
+  root has its source, so an unknown `srcDir` can't silently drop a live module) and any
+  dropped orphans are reported. As a safety net, an `already contains` import failure now
+  prints an actionable `lake clean` hint instead of a raw error.
+
 ## [0.9.3] - 2026-06-23
 
 ### Changed

--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -255,6 +255,16 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Name)
     importModules imports {} 0
   catch e =>
     let msg := toString e
+    if containsSubstring msg "already contains" then
+      -- Two imported modules declare the same name. Almost always a stale
+      -- "orphan" olean from a renamed/deleted module that Lake never GC'd
+      -- (issue #51). `getProjectModules` drops orphans with no backing source,
+      -- but a custom `srcDir` in a lakefile.lean (which we don't parse) can let
+      -- one slip through. A `lake clean` rebuild clears the stale artifacts.
+      let hint := "\n\nDuplicate declaration across imported modules — likely a stale .olean\n" ++
+        "from a renamed or deleted module that Lake did not remove.\n" ++
+        "Fix: run `lake clean` in the target project, then re-run extract."
+      return .error s!"Failed to import modules: {msg}{hint}"
     if containsSubstring msg "incompatible header" then
       let targetTC ← readToolchain projectPath
       let probeLeanVersion := Lean.versionString

--- a/ProbeLean/Environment.lean
+++ b/ProbeLean/Environment.lean
@@ -133,9 +133,12 @@ def loadCache (projectPath : System.FilePath) : IO (Option String) := do
   else
     return none
 
-/-- Recursively collect .olean files and convert to module names -/
-partial def collectOleanFiles (basePath : System.FilePath) (currentPath : System.FilePath) : IO (Array Lean.Name) := do
-  let mut result : Array Lean.Name := #[]
+/-- Recursively collect .olean files, returning for each its module name together
+    with its path relative to `basePath`, slash-separated and with the `.olean`
+    suffix stripped (e.g. `"A/B/C"`). The relative path is kept so callers can
+    reconstruct the backing source location under a library's `srcDir`. -/
+partial def collectOleanFiles (basePath : System.FilePath) (currentPath : System.FilePath) : IO (Array (Lean.Name × String)) := do
+  let mut result : Array (Lean.Name × String) := #[]
   let entries ← currentPath.readDir
   for entry in entries do
     let path := entry.path
@@ -148,18 +151,54 @@ partial def collectOleanFiles (basePath : System.FilePath) (currentPath : System
       let relPath := (relPath.dropPrefix "/").toString
       let relPath := (relPath.dropSuffix ".olean").toString
       let moduleName := relPath.replace "/" "."
-      result := result.push (String.toName moduleName)
+      result := result.push (String.toName moduleName, relPath)
   return result
 
-/-- Get the list of modules in the project by parsing lake output -/
+/-- Partition collected olean modules into (source-backed, orphan), where a
+    module with relative path `A/B/C` is source-backed iff `<root>/A/B/C.lean`
+    exists under some `root` in `sourceRoots`. An empty `sourceRoots` defaults to
+    `#["."]`. Conservative: a module is an orphan only when *no* root has its
+    source, so an unknown `srcDir` cannot silently drop a live module. -/
+def partitionBySource (projectPath : System.FilePath) (sourceRoots : Array String)
+    (oleans : Array (Lean.Name × String)) : IO (Array Lean.Name × Array Lean.Name) := do
+  let roots := if sourceRoots.isEmpty then #["."] else sourceRoots
+  let mut kept : Array Lean.Name := #[]
+  let mut orphans : Array Lean.Name := #[]
+  for (name, relPath) in oleans do
+    let mut hasSource := false
+    for root in roots do
+      let rootDir : System.FilePath := if root == "." then projectPath else projectPath / root
+      let srcFile : System.FilePath := ⟨rootDir.toString ++ "/" ++ relPath ++ ".lean"⟩
+      if ← srcFile.pathExists then
+        hasSource := true
+        break
+    if hasSource then
+      kept := kept.push name
+    else
+      orphans := orphans.push name
+  return (kept, orphans)
+
+/-- Get the list of the project's own modules by scanning its build directory
+    (`.lake/build/lib[/lean]`) for `.olean` files, keeping only modules that
+    still have a backing `.lean` source.
+
+    Lake never garbage-collects oleans, so after a file is renamed or deleted the
+    stale "orphan" olean lingers on disk. Importing such an orphan alongside the
+    module that replaced it makes `importModules` abort with
+    `environment already contains '...'` (see issue #51). We drop a module only
+    when *no* candidate source root has a source for it, so a missing `srcDir`
+    can never silently drop a live module; any dropped orphans are reported.
+
+    `sourceRoots` are the directories to resolve module paths against (a module
+    `A/B/C` is source-backed if `<root>/A/B/C.lean` exists under some root). It
+    must include `"."` plus every library `srcDir`; the caller supplies it. The
+    `lake env` call validates that the Lake environment is usable before scanning. -/
 def getProjectModules (projectPath : System.FilePath)
-    (nixMode : Option NixMode := none) : IO (Except String (Array Lean.Name)) := do
-  let (stdout, stderr, exitCode) ← runLakeCmd #["env", "printenv", "LEAN_PATH"] projectPath nixMode
+    (nixMode : Option NixMode := none) (sourceRoots : Array String := #["."])
+    : IO (Except String (Array Lean.Name)) := do
+  let (_, stderr, exitCode) ← runLakeCmd #["env", "printenv", "LEAN_PATH"] projectPath nixMode
   if exitCode != 0 then
     return .error s!"Failed to get LEAN_PATH:\n{stderr}"
-
-  -- Parse the LEAN_PATH to find olean directories
-  let _leanPath := stdout.trimAscii
 
   -- Find the project's build directory
   -- Some projects use .lake/build/lib/lean, others use .lake/build/lib directly
@@ -173,13 +212,21 @@ def getProjectModules (projectPath : System.FilePath)
     else
       pure buildLibPath
 
-  -- Collect all .olean files from the project's build directory
+  -- Collect all .olean files, then keep only those with a backing source.
   let mut modules : Array Lean.Name := #[]
+  let mut orphans : Array Lean.Name := #[]
 
   if ← projectBuildPath.pathExists then
     let oleans ← collectOleanFiles projectBuildPath projectBuildPath
-    for olean in oleans do
-      modules := modules.push olean
+    let (kept, dropped) ← partitionBySource projectPath sourceRoots oleans
+    modules := kept
+    orphans := dropped
+
+  if !orphans.isEmpty then
+    let sorted := orphans.qsort fun a b => a.toString < b.toString
+    IO.println s!"Ignoring {sorted.size} orphan module(s) with no backing .lean source (stale build artifacts):"
+    for o in sorted do
+      IO.println s!"  - {o}"
 
   -- Sort for deterministic import order (P14)
   let sortedModules := modules.qsort fun a b => a.toString < b.toString

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -208,7 +208,8 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   IO.println "=== Step 1/3: Atomize ==="
 
   IO.println "Getting project modules..."
-  let modules ← match ← getProjectModules config.projectPath nixMode with
+  let sourceRoots ← getSourceRoots config.projectPath
+  let modules ← match ← getProjectModules config.projectPath nixMode sourceRoots with
     | .error msg =>
       IO.eprintln msg
       return 1

--- a/ProbeLean/Metadata.lean
+++ b/ProbeLean/Metadata.lean
@@ -74,6 +74,39 @@ def parseLeanLibsFromToml (content : String) : Array String := Id.run do
           result := result.push (stripped.dropEnd 1).toString
   result
 
+/-- Extract every `srcDir = "..."` value declared under a `[[lean_lib]]` (or
+    `[[lean_exe]]`) section of a lakefile.toml string. Package-level `srcDir`
+    keys (outside any `[[...]]` table) are ignored. Used to know where a module's
+    backing source may live when filtering orphan oleans. -/
+def parseSrcDirsFromToml (content : String) : Array String := Id.run do
+  let mut result : Array String := #[]
+  let mut inTable := false
+  for line in content.splitOn "\n" do
+    let trimmed := line.trimAscii.toString
+    if trimmed.startsWith "[" then
+      inTable := true
+    if inTable && (trimmed.replace " " "").startsWith "srcDir" then
+      let parts := trimmed.splitOn "="
+      if parts.length >= 2 then
+        let valuePart := (String.intercalate "=" (parts.drop 1)).trimAscii.toString
+        if valuePart.startsWith "\"" && valuePart.endsWith "\"" then
+          let stripped := valuePart.drop 1
+          result := result.push (stripped.dropEnd 1).toString
+  result
+
+/-- Candidate source roots for resolving a module's backing `.lean` file:
+    always `"."` plus every `srcDir` declared in lakefile.toml. Deduplicated.
+    A `lakefile.lean` (Lean DSL) is not parsed, so its custom `srcDir`s are not
+    discovered — `getProjectModules` stays conservative and reports any drops. -/
+def getSourceRoots (projectPath : System.FilePath) : IO (Array String) := do
+  let tomlPath := projectPath / "lakefile.toml"
+  let mut roots : Array String := #["."]
+  if ← tomlPath.pathExists then
+    let content ← IO.FS.readFile tomlPath
+    for d in parseSrcDirsFromToml content do
+      if !roots.contains d then roots := roots.push d
+  return roots
+
 /-- Parse `defaultTargets = ["Lib1", "Lib2"]` from a lakefile.toml string. -/
 def parseDefaultTargetsFromToml (content : String) : Array String := Id.run do
   let mut result : Array String := #[]

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.9.3"
+def version : String := "0.9.4"
 
 end ProbeLean

--- a/README.md
+++ b/README.md
@@ -200,9 +200,13 @@ one.
   1. `--library <L1,L2,...>` if you pass it.
   2. otherwise `defaultTargets` from `lakefile.toml`.
   3. otherwise all `[[lean_lib]]` entries in `lakefile.toml`.
-- **Modules analyzed:** probe-lean collects **every `.olean` under
-  `.lake/build/lib/lean`** (which holds only the project's own modules — deps
-  live under `.lake/packages/`).
+- **Modules analyzed:** probe-lean collects every `.olean` under
+  `.lake/build/lib/lean` (which holds only the project's own modules — deps
+  live under `.lake/packages/`), then **keeps only modules that still have a
+  backing `.lean` source** — resolving each against `"."` plus every `srcDir`
+  declared in `lakefile.toml`. This drops *orphan* oleans left behind by renamed
+  or deleted modules (which Lake never garbage-collects); dropped modules are
+  reported.
   - **By default (no `--library`)** it analyzes **all** of them. Auto-detected
     build targets are *not* used as an analysis filter, because `defaultTargets`
     may name a `lean_exe` and a `lean_lib` may declare custom `roots` that differ
@@ -224,15 +228,18 @@ are imported into a **single Lean environment** before atomizing.
   module rather than writing an empty result.
 - **All analyzed modules must be mutually importable.** Two modules may not
   declare the same fully-qualified name, or the import aborts with
-  `environment already contains '<name>' from <module>`.
-- **Module discovery trusts the build directory, not git.** Because it scans
-  `.olean` files on disk, **orphan artifacts from modules you deleted or renamed
-  are still picked up until you `lake clean`.** An orphan that re-declares a
-  symbol is the most common cause of the duplicate-declaration import failure
-  above. When in doubt after a refactor, `lake clean` first.
+  `environment already contains '<name>' from <module>`. The usual cause —
+  orphan oleans from a rename — is now filtered out automatically (see above);
+  if it still fires (e.g. a `lakefile.lean` with a custom `srcDir` probe-lean
+  can't parse), the error includes a `lake clean` hint.
+- **Custom `srcDir` in a `lakefile.lean` is not parsed.** Source-backing is
+  resolved against `srcDir`s declared in `lakefile.toml` only. A library whose
+  custom `srcDir` lives in a Lean-DSL `lakefile.lean` may have its modules
+  reported as orphans; run `lake clean` and rebuild, or move the project to
+  `lakefile.toml`.
 
 > Resolving libraries to their actual Lake module roots (so `--library` works for
-> libraries with custom `roots`) and ignoring stale orphan oleans is tracked in
+> libraries with custom `roots`) is tracked in
 > [#40](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/40).
 
 ## Testing

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -2564,6 +2564,83 @@ def testParseDefaultTargets (result : TestResult) : IO TestResult := do
   try IO.FS.removeDirAll tmpBase catch _ => pure ()
   return result
 
+def testParseSrcDirs (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing parseSrcDirsFromToml..."
+
+  let noSrcDir := "name = \"Pkg\"\n\n[[lean_lib]]\nname = \"Pkg\"\n"
+  result ← test "no srcDir: returns empty" ((parseSrcDirsFromToml noSrcDir).size == 0) result
+
+  let oneSrcDir := "name = \"Pkg\"\n\n[[lean_lib]]\nname = \"Gen\"\nsrcDir = \"generated\"\n"
+  let s1 := parseSrcDirsFromToml oneSrcDir
+  result ← test "one srcDir: finds it" (s1.size == 1 && s1[0]? == some "generated") result
+
+  let twoSrcDirs := "name = \"Pkg\"\n\n[[lean_lib]]\nname = \"A\"\nsrcDir = \"src\"\n\n[[lean_lib]]\nname = \"B\"\nsrcDir = \"gen\"\n"
+  let s2 := parseSrcDirsFromToml twoSrcDirs
+  result ← test "two srcDirs: finds both" (s2.size == 2 && s2[0]? == some "src" && s2[1]? == some "gen") result
+
+  let spaced := "name = \"Pkg\"\n\n[[lean_lib]]\nname = \"A\"\nsrcDir=\"weird\"\n"
+  result ← test "srcDir without spaces around =" ((parseSrcDirsFromToml spaced)[0]? == some "weird") result
+
+  IO.println ""
+  IO.println "Testing getSourceRoots..."
+  let tmpBase : System.FilePath := "/tmp/probe-lean-test-srcroots-" ++ toString (← IO.monoNanosNow)
+  IO.FS.createDirAll tmpBase
+
+  IO.FS.writeFile (tmpBase / "lakefile.toml") twoSrcDirs
+  let r1 ← getSourceRoots tmpBase
+  result ← test "getSourceRoots includes '.'" (r1.contains ".") result
+  result ← test "getSourceRoots includes srcDirs" (r1.contains "src" && r1.contains "gen") result
+
+  -- No lakefile.toml → just "."
+  let emptyBase := tmpBase / "empty"
+  IO.FS.createDirAll emptyBase
+  let r2 ← getSourceRoots emptyBase
+  result ← test "getSourceRoots defaults to ['.'] without toml" (r2 == #["."]) result
+
+  try IO.FS.removeDirAll tmpBase catch _ => pure ()
+  return result
+
+def testOrphanOleanFilter (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing partitionBySource (orphan olean filtering)..."
+
+  let tmpBase : System.FilePath := "/tmp/probe-lean-test-orphan-" ++ toString (← IO.monoNanosNow)
+  -- Live sources at the default root.
+  IO.FS.createDirAll (tmpBase / "Pkg" / "Code")
+  IO.FS.writeFile (tmpBase / "Pkg" / "Lib.lean") ""
+  IO.FS.writeFile (tmpBase / "Pkg" / "Code" / "Live.lean") ""
+  -- A library with a custom srcDir.
+  IO.FS.createDirAll (tmpBase / "generated" / "Gen")
+  IO.FS.writeFile (tmpBase / "generated" / "Gen" / "Out.lean") ""
+
+  -- Olean entries as collectOleanFiles would produce them: (module name, relPath).
+  let oleans : Array (Lean.Name × String) := #[
+    (`Pkg.Lib, "Pkg/Lib"),
+    (`Pkg.Code.Live, "Pkg/Code/Live"),
+    (`Pkg.Code.Orphan, "Pkg/Code/Orphan"),   -- renamed/deleted: no source
+    (`Gen.Out, "Gen/Out")                     -- source only under srcDir "generated"
+  ]
+
+  let (kept0, orphans0) ← partitionBySource tmpBase #["."] oleans
+  result ← test "default root: orphan dropped" (!kept0.contains `Pkg.Code.Orphan && orphans0.contains `Pkg.Code.Orphan) result
+  result ← test "default root: live modules kept" (kept0.contains `Pkg.Lib && kept0.contains `Pkg.Code.Live) result
+  result ← test "default root: custom-srcDir module dropped (no '.' source)" (orphans0.contains `Gen.Out) result
+
+  let (kept1, orphans1) ← partitionBySource tmpBase #[".", "generated"] oleans
+  result ← test "with srcDir: custom-srcDir module kept" (kept1.contains `Gen.Out) result
+  result ← test "with srcDir: orphan still dropped" (orphans1.contains `Pkg.Code.Orphan) result
+  result ← test "with srcDir: only the orphan is dropped" (orphans1.size == 1) result
+
+  -- Empty sourceRoots falls back to ["."].
+  let (kept2, _) ← partitionBySource tmpBase #[] oleans
+  result ← test "empty roots fall back to '.'" (kept2.contains `Pkg.Lib && !kept2.contains `Pkg.Code.Orphan) result
+
+  try IO.FS.removeDirAll tmpBase catch _ => pure ()
+  return result
+
 def testSelectModules (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -3193,6 +3270,8 @@ def main : IO UInt32 := do
   result ← testLeanInvariants result
   result ← testParseLeanLibs result
   result ← testParseDefaultTargets result
+  result ← testParseSrcDirs result
+  result ← testOrphanOleanFilter result
   result ← testSelectModules result
   result ← testVersionConsistency result
   result ← testCacheValidity result

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -336,6 +336,10 @@ You're almost certainly compiling Mathlib from source. probe-lean auto-downloads
 
 The project has multiple modules that define `main`. This typically happens with utility scripts included as `[[lean_lib]]`. Use `--library` to target only the main library, or ensure the project's `defaultTargets` excludes conflicting libraries.
 
+### "environment already contains '...'" after renaming or deleting a file
+
+A stale *orphan* `.olean` from the old module is still on disk (Lake never removes oleans for deleted/renamed sources) and re-declares a name now owned by another module. probe-lean drops orphan oleans automatically by checking each module against its backing `.lean` source — but it only knows `srcDir`s declared in `lakefile.toml`. If your project uses a Lean-DSL `lakefile.lean` with a custom `srcDir`, the orphan may slip through; the error message includes a `lake clean` hint. Run `lake clean && lake build` in the target project, then re-run extract.
+
 ### "Failed to import modules"
 
 The `.olean` files may be stale or from a different toolchain version. Clean and rebuild:

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.9.3"
+version = "0.9.4"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
Closes #51.

## Problem

`extract` discovered modules by scanning `.lake/build/lib/lean` for every `.olean` and importing them all into a single environment. Lake never garbage-collects oleans, so after a `.lean` file is renamed or deleted its stale *orphan* olean lingers. When the orphan re-declares a name now owned by the module that replaced it, the import aborts with `environment already contains '...'`. `lake build` never trips on this because it follows imports from live sources and never loads the orphan; extraction does, because it enumerates oleans on disk and forces them into one environment.

## Fix

- **Source-existence filter (the fix).** `getProjectModules` now keeps only modules with a backing `.lean`, resolving each module's relative path against `"."` plus every `srcDir` declared in `lakefile.toml`. The rule is conservative — a module is dropped only when *no* source root has its source, so an unknown `srcDir` can't silently drop a live module — and dropped orphans are reported.
- **Safety net.** An `already contains` import failure now returns an actionable `lake clean` hint instead of a raw abort, covering the residual case (e.g. a `lakefile.lean` with a custom `srcDir` we don't parse).

## Tests

`testParseSrcDirs` and `testOrphanOleanFilter` (temp-dir fixture: orphan dropped, live kept, custom-`srcDir` dropped-then-kept, only-the-orphan-dropped, empty-roots fallback). Full suite: 542 passed, 0 failed.

## Notes

- Out of scope (tracked in #40): resolving libraries to their actual Lake module roots.
- Patch bump to 0.9.4; README/USAGE/CHANGELOG updated. Output format unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)