### PR TITLE
Auto-release probe-lean artifacts for new Lean versions (#38)

### DIFF
--- a/.github/workflows/lean-watch.yml
+++ b/.github/workflows/lean-watch.yml
@@ -1,0 +1,262 @@
+name: Lean watch
+
+# Watches leanprover/lean4 for new Lean versions and builds probe-lean artifacts
+# for any supported version not yet present on the latest release, appending them
+# to that release. A version probe-lean cannot build (breaking upstream change, or
+# lean4-cli not yet tagged) is reported in a single tracking issue rather than
+# failing the run; the next scheduled run retries it. See
+# specs/done/auto-release-lean-versions.md and issue #38.
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # upload release assets
+  issues: write # maintain the tracking issue
+
+# Serialize watcher runs so two don't try to upload the same asset at once.
+concurrency:
+  group: lean-watch
+  cancel-in-progress: false
+
+# The platform tokens that appear in artifact names, one per build runner
+# (ubuntu-latest -> linux-x86_64, macos-latest -> darwin-arm64). A version is
+# "covered" only when an asset exists for every one of these. Keep this in sync
+# with the build matrix below; the build job asserts its detected platform is
+# listed here, so a runner whose arch changes fails loudly instead of looping.
+env:
+  EXPECTED_PLATFORMS: "linux-x86_64 darwin-arm64"
+  ISSUE_LABEL: lean-build-failure
+
+jobs:
+  compute:
+    name: Find versions needing artifacts
+    runs-on: ubuntu-latest
+    outputs:
+      have_release: ${{ steps.plan.outputs.have_release }}
+      target: ${{ steps.plan.outputs.target }}
+      versions: ${{ steps.plan.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve target release and missing versions
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The "latest release" endpoint excludes drafts and prereleases, so the
+          # target is always a real, published release — never an in-progress tag.
+          if ! target=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" -q .tag_name 2>/dev/null); then
+            echo "No published release to attach artifacts to — nothing to do."
+            {
+              echo "have_release=false"
+              echo "target="
+              echo "versions=[]"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Target release: $target"
+
+          assets=$(gh release view "$target" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name')
+
+          # A version needs work if any expected platform's tarball is absent.
+          # Exact whole-line fixed-string match (grep -xF) means a stable
+          # (v4.32.0) is never confused with its RC assets (v4.32.0-rc1-...).
+          missing='[]'
+          for v in $(tools/lean-versions.sh --json | jq -r '.[]'); do
+            for plat in $EXPECTED_PLATFORMS; do
+              if ! printf '%s\n' "$assets" | grep -qxF "probe-lean-${v}-${plat}.tar.gz"; then
+                missing=$(printf '%s' "$missing" | jq --arg v "$v" '. + [$v]')
+                break
+              fi
+            done
+          done
+          missing=$(printf '%s' "$missing" | jq -c .)
+          echo "Versions needing artifacts: $missing"
+          {
+            echo "have_release=true"
+            echo "target=$target"
+            echo "versions=$missing"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.lean-version }} (${{ matrix.os }})
+    needs: compute
+    if: needs.compute.outputs.have_release == 'true' && needs.compute.outputs.versions != '[]'
+    runs-on: ${{ matrix.os }}
+    env:
+      TARGET: ${{ needs.compute.outputs.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        lean-version: ${{ fromJSON(needs.compute.outputs.versions) }}
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect platform
+        id: platform
+        run: |
+          set -euo pipefail
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            aarch64|arm64) ARCH="arm64" ;;
+            x86_64)        ARCH="x86_64" ;;
+          esac
+          platform="${OS}-${ARCH}"
+          # Coverage in `compute`/`report` keys on EXPECTED_PLATFORMS; if this runner
+          # reports something else, fail loudly rather than uploading an asset that
+          # coverage will never recognise (which would rebuild it forever).
+          case " $EXPECTED_PLATFORMS " in
+            *" $platform "*) ;;
+            *) echo "::error::Detected platform '$platform' is not in EXPECTED_PLATFORMS ($EXPECTED_PLATFORMS)."; exit 1 ;;
+          esac
+          echo "platform=${platform}" >> "$GITHUB_OUTPUT"
+
+      # Per (version, platform) idempotency: if this exact tarball already exists
+      # on the target release, do nothing — never rebuild or overwrite it.
+      - name: Check whether this artifact already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          name="probe-lean-${{ matrix.lean-version }}-${{ steps.platform.outputs.platform }}.tar.gz"
+          if gh release view "$TARGET" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name' \
+              | grep -qxF "$name"; then
+            echo "$name already present — skipping."
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rewrite toolchain to target Lean version
+        if: steps.exists.outputs.present == 'false'
+        run: |
+          echo "leanprover/lean4:${{ matrix.lean-version }}" > lean-toolchain
+          sed -i.bak -e 's/rev = "v[^"]*"/rev = "${{ matrix.lean-version }}"/' lakefile.toml
+          rm -f lakefile.toml.bak
+          # Re-resolve Cli against the rewritten rev (issue #38).
+          rm -rf .lake lake-manifest.json
+
+      # A build failure is expected for some versions; tolerate it and let the
+      # report job record it. The steps below run only on a clean build.
+      - uses: leanprover/lean-action@v1
+        id: build
+        if: steps.exists.outputs.present == 'false'
+        continue-on-error: true
+        with:
+          test: false
+
+      - name: Report unbuildable version
+        if: steps.exists.outputs.present == 'false' && steps.build.outcome != 'success'
+        run: |
+          echo "::warning::probe-lean failed to build against Lean ${{ matrix.lean-version }} on ${{ matrix.os }}."
+
+      - name: Smoke test
+        if: steps.exists.outputs.present == 'false' && steps.build.outcome == 'success'
+        run: .lake/build/bin/probe-lean --version
+
+      - name: Package binary, .olean files, and provenance
+        if: steps.exists.outputs.present == 'false' && steps.build.outcome == 'success'
+        run: |
+          ARTIFACT="probe-lean-${{ matrix.lean-version }}-${{ steps.platform.outputs.platform }}"
+          mkdir -p "$ARTIFACT/bin" "$ARTIFACT/lib"
+          cp .lake/build/bin/probe-lean "$ARTIFACT/bin/"
+          cp -r .lake/build/lib/lean/ProbeLean* "$ARTIFACT/lib/"
+          # Provenance: a watcher artifact is built from main, so record exactly
+          # which probe-lean revision produced it.
+          {
+            echo "probe-lean-commit=${{ github.sha }}"
+            echo "probe-lean-ref=${{ github.ref_name }}"
+            echo "lean-version=${{ matrix.lean-version }}"
+            echo "built-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "built-by=lean-watch"
+          } > "$ARTIFACT/BUILDINFO"
+          tar -czf "${ARTIFACT}.tar.gz" -C "$ARTIFACT" bin lib BUILDINFO
+          # shasum is present on both ubuntu and macOS runners (sha256sum is not).
+          shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
+          echo "ARTIFACT=${ARTIFACT}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Upload artifact (never overwrite the tarball)
+        if: steps.exists.outputs.present == 'false' && steps.build.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Upload the checksum first (the tarball is the coverage key, so it must
+          # never appear without its sidecar). The sidecar may be --clobbered — it
+          # is a deterministic hash, safe to replace, which also lets a retry after
+          # a partial upload self-heal. The tarball is uploaded WITHOUT --clobber:
+          # a watcher build (from main) must never overwrite an existing artifact
+          # (e.g. one built from tagged source). A genuine upload/auth error — or a
+          # tarball that unexpectedly already exists — fails the job loudly rather
+          # than being misreported as a build failure.
+          gh release upload "$TARGET" "${ARTIFACT}.sha256" --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "$TARGET" "$ARTIFACT" --repo "$GITHUB_REPOSITORY"
+
+  report:
+    name: Update build-failure tracking issue
+    needs: [compute, build]
+    if: always() && needs.compute.outputs.have_release == 'true'
+    runs-on: ubuntu-latest
+    env:
+      TARGET: ${{ needs.compute.outputs.target }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Recompute coverage and open/update/close the tracking issue
+        run: |
+          set -euo pipefail
+          assets=$(gh release view "$TARGET" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name')
+
+          # Same coverage check as compute: any expected platform still missing an
+          # asset after the build job ran.
+          missing=""
+          for v in $(tools/lean-versions.sh --json | jq -r '.[]'); do
+            missing_plat=""
+            for plat in $EXPECTED_PLATFORMS; do
+              if ! printf '%s\n' "$assets" | grep -qxF "probe-lean-${v}-${plat}.tar.gz"; then
+                missing_plat="${missing_plat}${missing_plat:+, }${plat}"
+              fi
+            done
+            if [ -n "$missing_plat" ]; then
+              missing="${missing}- \`${v}\` — missing: ${missing_plat}\n"
+            fi
+          done
+
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "$ISSUE_LABEL" \
+            --state open --json number -q '.[0].number // empty')
+
+          if [ -z "$missing" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
+                --comment "All supported Lean versions now have artifacts on \`$TARGET\`. Closing."
+            fi
+            echo "All supported Lean versions are covered."
+            exit 0
+          fi
+
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          body=$(printf 'probe-lean could not produce artifacts for these Lean versions on release `%s` (run: %s):\n\n%bMaintained automatically by the Lean watcher: this body is regenerated each run and the issue is closed when every version builds. A version usually fails because of a breaking Lean change or because lean4-cli has not yet tagged the matching version.\n' \
+            "$TARGET" "$run_url" "$missing")
+
+          # Ensure the label exists (no-op if already created).
+          gh label create "$ISSUE_LABEL" --repo "$GITHUB_REPOSITORY" \
+            --color B60205 --description "Automated: probe-lean fails to build against a Lean version" 2>/dev/null || true
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+            echo "Updated tracking issue #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Automated: probe-lean build failures for new Lean versions" \
+              --label "$ISSUE_LABEL" --body "$body"
+          fi

--- a/.github/workflows/lean-watch.yml
+++ b/.github/workflows/lean-watch.yml
@@ -16,9 +16,10 @@ permissions:
   contents: write # upload release assets
   issues: write # maintain the tracking issue
 
-# Serialize watcher runs so two don't try to upload the same asset at once.
+# Shared with release.yml: serializes watcher runs against each other AND against
+# a tagged release, so the two never write to the same release's assets at once.
 concurrency:
-  group: lean-watch
+  group: probe-lean-release-assets
   cancel-in-progress: false
 
 # The platform tokens that appear in artifact names, one per build runner
@@ -140,8 +141,14 @@ jobs:
         if: steps.exists.outputs.present == 'false'
         run: |
           echo "leanprover/lean4:${{ matrix.lean-version }}" > lean-toolchain
-          sed -i.bak -e 's/rev = "v[^"]*"/rev = "${{ matrix.lean-version }}"/' lakefile.toml
-          rm -f lakefile.toml.bak
+          # Rewrite the rev of ONLY the lean4-cli dependency — not every
+          # rev = "v..." — so a future second pinned [[require]] is left alone.
+          awk -v ver="${{ matrix.lean-version }}" '
+            /^[[:space:]]*\[\[/ { incli = 0 }
+            /git = ".*lean4-cli"/ { incli = 1 }
+            incli && /^[[:space:]]*rev[[:space:]]*=/ { sub(/"v[^"]*"/, "\"" ver "\"") }
+            { print }
+          ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
           # Re-resolve Cli against the rewritten rev (issue #38).
           rm -rf .lake lake-manifest.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,18 @@ on:
 permissions:
   contents: write
 
-# Serialize runs for the same tag so reruns / overlapping pushes don't race on
-# the release's assets.
+# Shared with lean-watch.yml: the watcher and a tagged release must never write to
+# the same release's assets concurrently (avoids clobbering each other's tarballs
+# and leaving a checksum pointing at the wrong bytes).
 concurrency:
-  group: release-${{ inputs.tag || github.ref_name }}
+  group: probe-lean-release-assets
   cancel-in-progress: false
+
+# Platforms the build matrix produces (ubuntu-latest -> linux-x86_64,
+# macos-latest -> darwin-arm64). The platform-detect step asserts the runner
+# reports one of these, so an unexpected arch fails loudly.
+env:
+  EXPECTED_PLATFORMS: "linux-x86_64 darwin-arm64"
 
 jobs:
   compute:
@@ -92,9 +99,14 @@ jobs:
       - name: Rewrite toolchain to target Lean version
         run: |
           echo "leanprover/lean4:${{ matrix.lean-version }}" > lean-toolchain
-          # sed -i.bak works on both GNU (Linux) and BSD (macOS) sed.
-          sed -i.bak -e 's/rev = "v[^"]*"/rev = "${{ matrix.lean-version }}"/' lakefile.toml
-          rm -f lakefile.toml.bak
+          # Rewrite the rev of ONLY the lean4-cli dependency — not every
+          # rev = "v..." — so a future second pinned [[require]] is left alone.
+          awk -v ver="${{ matrix.lean-version }}" '
+            /^[[:space:]]*\[\[/ { incli = 0 }
+            /git = ".*lean4-cli"/ { incli = 1 }
+            incli && /^[[:space:]]*rev[[:space:]]*=/ { sub(/"v[^"]*"/, "\"" ver "\"") }
+            { print }
+          ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
           # Drop the committed manifest and build dir so Lake re-resolves Cli
           # against the rewritten rev — otherwise the pinned manifest wins and the
           # build silently uses the wrong lean4-cli (issue #38).
@@ -123,13 +135,21 @@ jobs:
         if: steps.build.outcome == 'success'
         id: platform
         run: |
+          set -euo pipefail
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m)
           case "$ARCH" in
             aarch64|arm64) ARCH="arm64" ;;
             x86_64)        ARCH="x86_64" ;;
           esac
-          echo "platform=${OS}-${ARCH}" >> $GITHUB_OUTPUT
+          platform="${OS}-${ARCH}"
+          # Fail loudly on an unexpected runner arch rather than publishing an
+          # artifact name the installers and watcher coverage never expect.
+          case " $EXPECTED_PLATFORMS " in
+            *" $platform "*) ;;
+            *) echo "::error::Detected platform '$platform' is not in EXPECTED_PLATFORMS ($EXPECTED_PLATFORMS)."; exit 1 ;;
+          esac
+          echo "platform=${platform}" >> "$GITHUB_OUTPUT"
 
       - name: Package binary and .olean files
         if: steps.build.outcome == 'success'
@@ -146,27 +166,56 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           gh release upload "$RELEASE_TAG" "$ARTIFACT" --repo "$GITHUB_REPOSITORY" --clobber
+          # If the watcher previously published this tarball it also uploaded a
+          # .sha256 sidecar; that checksum now refers to the bytes we just replaced,
+          # so delete it (release.yml itself doesn't publish checksums).
+          gh release delete-asset "$RELEASE_TAG" "${ARTIFACT}.sha256" \
+            --repo "$GITHUB_REPOSITORY" --yes 2>/dev/null || true
 
   verify:
-    name: Verify the release has at least one artifact
-    needs: [build]
+    name: Verify release coverage
+    needs: [compute, build]
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
-      # Guards the systemic-failure case (e.g. nothing built on a fresh release).
-      # This counts the release's current assets, not only this run's uploads.
-      - name: Fail if the release has no probe-lean artifacts
+      # Per-version builds are continue-on-error, so summarise which
+      # (version, platform) actually landed and fail only if the release has none.
+      - name: Summarise coverage and fail if empty
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          count=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --json assets \
-            -q '[.assets[].name | select(test("^probe-lean-.*\\.tar\\.gz$"))] | length')
-          echo "Release $RELEASE_TAG has $count probe-lean artifact(s)."
-          if [ "$count" -eq 0 ]; then
+          assets=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name')
+          {
+            echo "### Release $RELEASE_TAG artifact coverage"
+            echo ""
+            echo "| Lean version | platform | built |"
+            echo "| --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          total=0; present=0
+          for v in $(printf '%s' '${{ needs.compute.outputs.versions }}' | jq -r '.[]'); do
+            for plat in $EXPECTED_PLATFORMS; do
+              total=$((total + 1))
+              if printf '%s\n' "$assets" | grep -qxF "probe-lean-${v}-${plat}.tar.gz"; then
+                present=$((present + 1)); mark="✅"
+              else
+                mark="❌"
+              fi
+              echo "| \`$v\` | $plat | $mark |" >> "$GITHUB_STEP_SUMMARY"
+            done
+          done
+          {
+            echo ""
+            echo "**$present / $total** expected artifacts present on \`$RELEASE_TAG\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Release $RELEASE_TAG: $present/$total expected artifacts present."
+          # Fail only on systemic failure (nothing built at all), matching the
+          # accepted fail-soft policy; partial coverage is surfaced above, not failed.
+          all=$(printf '%s\n' "$assets" | grep -Ec '^probe-lean-.*\.tar\.gz$' || true)
+          if [ "$all" -eq 0 ]; then
             echo "::error::Release $RELEASE_TAG has no probe-lean artifacts."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,41 +13,114 @@ on:
 permissions:
   contents: write
 
+# Serialize runs for the same tag so reruns / overlapping pushes don't race on
+# the release's assets.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
+  compute:
+    name: Compute Lean version matrix
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.derive.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive supported Lean versions
+        id: derive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # jq -c keeps it a single line — multi-line values break $GITHUB_OUTPUT.
+          # `if !` checks the pipeline's exit regardless of the runner's shell
+          # defaults (which may lack pipefail).
+          if ! versions=$(tools/lean-versions.sh --json | jq -c .); then
+            echo "::error::Failed to derive supported Lean versions from the leanprover/lean4 releases."
+            exit 1
+          fi
+          echo "Building for: $versions"
+          if [ -z "$versions" ] || [ "$versions" = "[]" ]; then
+            echo "::error::No supported Lean versions were derived."
+            exit 1
+          fi
+          printf 'versions=%s\n' "$versions" >> "$GITHUB_OUTPUT"
+
+  ensure-release:
+    name: Ensure release exists
+    needs: compute
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+    steps:
+      # Create the release once, here, rather than racing to create it from every
+      # matrix row. A genuine API/auth failure fails loudly instead of being
+      # swallowed by `|| true`.
+      - name: Create release if missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists."
+          else
+            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --generate-notes
+          fi
+
   build:
     name: Build probe-lean (${{ matrix.lean-version }}, ${{ matrix.os }})
+    needs: [compute, ensure-release]
     runs-on: ${{ matrix.os }}
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
-        lean-version:
-          - v4.28.0-rc1
-          - v4.28.0
-          - v4.29.0-rc4
-          - v4.29.0-rc8
-          - v4.29.0
-          - v4.30.0-rc2
-          - v4.30.0
-          - v4.31.0
+        lean-version: ${{ fromJSON(needs.compute.outputs.versions) }}
         os:
           - ubuntu-latest
           - macos-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Build the source that matches the release we upload to: the pushed tag,
+          # or the tag given to a manual dispatch (not whatever branch dispatched it).
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Rewrite toolchain to target Lean version
         run: |
           echo "leanprover/lean4:${{ matrix.lean-version }}" > lean-toolchain
-          sed -i'' -e 's/rev = "v[^"]*"/rev = "${{ matrix.lean-version }}"/' lakefile.toml
+          # sed -i.bak works on both GNU (Linux) and BSD (macOS) sed.
+          sed -i.bak -e 's/rev = "v[^"]*"/rev = "${{ matrix.lean-version }}"/' lakefile.toml
+          rm -f lakefile.toml.bak
+          # Drop the committed manifest and build dir so Lake re-resolves Cli
+          # against the rewritten rev — otherwise the pinned manifest wins and the
+          # build silently uses the wrong lean4-cli (issue #38).
+          rm -rf .lake lake-manifest.json
 
+      # A build failure here is expected for some Lean versions (breaking upstream
+      # changes, or lean4-cli not yet tagged). Tolerate it per-version so one bad
+      # version cannot fail the whole release; the steps below run only on success,
+      # and the `verify` job fails the run if *nothing* built.
       - uses: leanprover/lean-action@v1
+        id: build
+        continue-on-error: true
         with:
           test: false
 
+      - name: Report unbuildable version
+        if: steps.build.outcome != 'success'
+        run: |
+          echo "::warning::probe-lean failed to build against Lean ${{ matrix.lean-version }} on ${{ matrix.os }} — no artifact produced."
+
+      - name: Smoke test
+        if: steps.build.outcome == 'success'
+        run: .lake/build/bin/probe-lean --version
+
       - name: Detect platform
+        if: steps.build.outcome == 'success'
         id: platform
         run: |
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -59,6 +132,7 @@ jobs:
           echo "platform=${OS}-${ARCH}" >> $GITHUB_OUTPUT
 
       - name: Package binary and .olean files
+        if: steps.build.outcome == 'success'
         run: |
           ARTIFACT="probe-lean-${{ matrix.lean-version }}-${{ steps.platform.outputs.platform }}"
           mkdir -p "$ARTIFACT/bin" "$ARTIFACT/lib"
@@ -67,14 +141,32 @@ jobs:
           tar -czf "${ARTIFACT}.tar.gz" -C "$ARTIFACT" bin lib
           echo "ARTIFACT=${ARTIFACT}.tar.gz" >> $GITHUB_ENV
 
-      - name: Create release if needed
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "$RELEASE_TAG" --generate-notes 2>/dev/null || true
-
       - name: Upload release asset
+        if: steps.build.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "$RELEASE_TAG" "$ARTIFACT" --clobber
+          gh release upload "$RELEASE_TAG" "$ARTIFACT" --repo "$GITHUB_REPOSITORY" --clobber
+
+  verify:
+    name: Verify the release has at least one artifact
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+    steps:
+      # Guards the systemic-failure case (e.g. nothing built on a fresh release).
+      # This counts the release's current assets, not only this run's uploads.
+      - name: Fail if the release has no probe-lean artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets \
+            -q '[.assets[].name | select(test("^probe-lean-.*\\.tar\\.gz$"))] | length')
+          echo "Release $RELEASE_TAG has $count probe-lean artifact(s)."
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Release $RELEASE_TAG has no probe-lean artifacts."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 .DS_Store
 Thumbs.db
 atoms.json
+
+# Python artifacts (tools/python)
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ export PATH="$PATH:$HOME/.local/bin"
 
 For all installer options (`--force`, `--lean-version`, cloned-repo usage, etc.), see **[docs/USAGE.md](docs/USAGE.md#installer-flags)**.
 
+### Pre-built binary availability
+
+probe-lean publishes a pre-built binary per `(Lean version, platform)` on its GitHub
+releases, for `linux-x86_64` and `darwin-arm64`. The set of Lean versions tracked is:
+
+- every **stable** Lean release at or above `v4.28.0-rc1`, plus
+- the **latest release candidate** of any version line that has not yet shipped a stable.
+
+These are generated automatically: a scheduled workflow watches `leanprover/lean4` and
+builds probe-lean for any newly released Lean version within about a day, appending the
+artifact to the latest release (no probe-lean release is needed). If probe-lean cannot yet
+build against a brand-new Lean version (e.g. a breaking change, or `lean4-cli` has not
+tagged the matching version), it is tracked in an issue and retried automatically.
+
+If no pre-built binary exists for your toolchain — an unsupported, superseded, or very new
+Lean version — the installer transparently falls back to building from source.
+
 ### Docker
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -52,6 +52,10 @@ probe-lean **must** be installed for the same Lean version as the target project
 
 If your targets use different Lean versions, the installer handles this: it builds (or downloads) a versioned binary for each version. Multiple versions coexist under `~/.local/bin/probe-lean-v<version>`. The `probe-lean` symlink points to the most recently installed version.
 
+### Pre-built binary availability
+
+Pre-built binaries are published for `linux-x86_64` and `darwin-arm64` for every stable Lean release `≥ v4.28.0-rc1`, plus the latest release candidate of any line without a stable. A scheduled workflow builds artifacts for new Lean versions automatically (usually within a day of an upstream release), so a recent toolchain normally has a binary ready. If yours doesn't — a superseded RC, a very new release probe-lean cannot build yet, or an unsupported version — the installer falls back to a source build. To raise the GitHub API rate limit during the lookup, set `GH_TOKEN` (or `GITHUB_TOKEN`).
+
 ---
 
 ## Commands

--- a/specs/done/auto-release-lean-versions.md
+++ b/specs/done/auto-release-lean-versions.md
@@ -1,0 +1,127 @@
+# Feature: Auto-release probe-lean artifacts for new Lean versions
+
+Tracking issue: [#38](https://github.com/Beneficial-AI-Foundation/probe-lean/issues/38)
+
+## Summary
+
+Automatically produce `probe-lean` release artifacts when upstream `leanprover/lean4`
+publishes a new Lean version, instead of requiring a human to edit a hardcoded version
+matrix and cut a release. A scheduled "watcher" workflow polls the Lean releases API,
+computes the set of Lean versions probe-lean should support, builds probe-lean against any
+version not already present on the latest release, and appends the resulting tarballs to
+that release. When probe-lean fails to build against a new Lean version (expected
+periodically, given Lean's breaking changes and the `lean4-cli` rev coupling), the watcher
+reports it in a single tracking issue instead of failing silently or marking the run red.
+
+## Motivation
+
+The Lean version matrix was hardcoded in [`.github/workflows/release.yml`](../../.github/workflows/release.yml)
+(8 versions × 2 runner OSes). When Lean shipped a new version, no `probe-lean-<lean-version>-*`
+artifact existed until someone manually appended to that list and cut a release. The
+installer ([`tools/bash/install.sh`](../../tools/bash/install.sh), `tools/python/install.py`)
+locates artifacts by filename across GitHub releases, so the probe-lean release tag is already
+decoupled from which Lean versions live inside it — meaning new artifacts can be appended
+without a probe-lean version bump.
+
+Three realities shape the design:
+
+1. **Lean has frequent breaking API changes.** probe-lean's source may not compile against a
+   brand-new Lean version unmodified. Automation must treat a build failure as an expected,
+   *reportable* outcome — distinct from an infrastructure/auth/upload failure, which must fail
+   loudly.
+2. **The `lean4-cli` dependency is rev-coupled to the Lean version.** The build rewrites the
+   `Cli` `rev` in `lakefile.toml` to match the Lean version tag. A new Lean release will not
+   build until `leanprover/lean4-cli` publishes a matching tag, so "Lean released" does not
+   imply "buildable yet."
+3. **`lake-manifest.json` independently pins `Cli`.** Rewriting only `lakefile.toml` and
+   running `lake build` against a stale manifest can build the *wrong* `Cli` revision — a
+   latent correctness bug `release.yml` had, which this feature fixes in every build path.
+
+## Spec workflow
+
+The feature has four parts: a shared policy script, the watcher (the new automation), the
+hardened tagged-release workflow, and the installer lookup.
+
+### 1. Version policy — `tools/lean-versions.sh`
+
+The single source of truth for "which Lean versions does probe-lean support." It fetches the
+`leanprover/lean4` releases (via `gh api --paginate`, `curl`, or a fixture file for tests),
+validates the response, and applies the policy:
+
+> every **stable** release at/above the floor (`LEAN_VERSION_FLOOR`, default `v4.28.0-rc1`),
+> plus the **latest release candidate** of any version line that has not yet shipped a stable.
+
+It compares versions with a bounded numeric sort key, so RCs order numerically (`rc10 > rc2`)
+and below their own stable (`v4.29.0-rc8 < v4.29.0`). `--json` emits an array for a GitHub
+Actions matrix. Fixture-based tests live in `tests/lean-versions/`.
+
+### 2. The watcher — `.github/workflows/lean-watch.yml` (the feature)
+
+Runs daily on a schedule (and on manual dispatch); a `lean-watch` concurrency group keeps two
+runs from overlapping. Three jobs:
+
+- **compute** — resolves the **latest published release** (`releases/latest`, which excludes
+  drafts/prereleases) as the target. For each supported version it checks whether an artifact
+  exists for every expected platform (`linux-x86_64`, `darwin-arm64`); versions missing one go
+  into the matrix. No
+  published release ⇒ the run no-ops.
+- **build** — a matrix of `(missing version × {ubuntu-latest, macos-latest})`. Each job: detect
+  its platform → skip if that exact `probe-lean-<version>-<platform>.tar.gz` already exists →
+  rewrite `lean-toolchain` + the `Cli` rev and remove `.lake`/`lake-manifest.json` → build (the
+  build step is `continue-on-error`) → on a clean build only: `--version` smoke test, package
+  the tarball with a `BUILDINFO` provenance file and a `.sha256`, then upload (sidecar first
+  with `--clobber`, tarball **without** `--clobber`).
+- **report** — recomputes coverage from the release's current assets and opens / updates /
+  closes the single `lean-build-failure` tracking issue.
+
+End to end: a new Lean version → an artifact appears on the latest release within ~a day; an
+unbuildable one → it shows up in the tracking issue and is retried each run until probe-lean
+(or `lean4-cli`) catches up.
+
+### 3. Tagged releases — `.github/workflows/release.yml`
+
+Fires on a probe-lean version tag (`v*`). Rebuilds the **full** supported set from the tagged
+source: `compute` (derives the matrix from `tools/lean-versions.sh`) → `ensure-release`
+(creates the release once) → `build` (same rewrite + manifest-cleanup + smoke-test recipe as
+the watcher, `continue-on-error` per version, uploads with `--clobber` since it owns its tag's
+release) → `verify` (fails the run if the release has no artifacts). A per-tag
+concurrency group serializes reruns.
+
+### 4. Installer lookup — `tools/bash/install.sh`, `tools/python/install.py`
+
+When installing, the installer searches the releases for `probe-lean-<version>-<platform>.tar.gz`,
+requesting `per_page=100` (one call covers every probe-lean release for the foreseeable future)
+with an optional `GH_TOKEN`/`GITHUB_TOKEN`. If no prebuilt is found it falls back to a source
+build — so a toolchain without a published artifact still works, just slower.
+
+## Things to note
+
+- **Both workflows derive the version set live; there is no committed version-pin file.** A
+  tagged release builds whatever the policy yields at the moment it runs, so the exact artifact
+  set is not reproducible from the tag alone. This is accepted: a single unbuildable version is
+  skipped (warning), and `verify` only fails the run if the release has no artifacts at all.
+- **Support policy / floor.** Floor is `v4.28.0-rc1` (the documented minimum and probe-lean's
+  own toolchain). A superseded RC (a line that has since shipped stable) is *not* actively
+  rebuilt, but its already-published artifact is **never deleted**, so existing consumers are
+  unaffected. Raising the floor later is a deliberate decision that must update the docs.
+- **`lean4-cli` coupling.** A brand-new Lean version often cannot build until `lean4-cli`
+  publishes the matching tag; the watcher treats this like any build failure and retries.
+- **Stale-manifest bug fixed.** Every build path now removes `.lake` + `lake-manifest.json`
+  after the rewrite. The macOS-incompatible `sed -i''` was also replaced with portable
+  `sed -i.bak` — together these likely affected past macOS release artifacts.
+- **Platforms.** Only `linux-x86_64` and `darwin-arm64` (what `ubuntu-latest`/`macos-latest`
+  yield). Coverage is checked against the exact expected platform names; the build job asserts
+  its detected platform is one of them, so a runner-arch change fails loudly instead of looping.
+  Adding more arches is out of scope.
+- **Provenance.** Watcher artifacts (built from `main`) carry a `BUILDINFO` (commit SHA, ref,
+  Lean version, build time) and a `.sha256`. Tagged-release artifacts do not (the tag is their
+  provenance); coverage is keyed on the tarball, so the asymmetry is fine.
+- **No-clobber boundary.** The watcher never overwrites a tarball; `release.yml` uses
+  `--clobber` because it owns its tag's release. The two workflows are not in a shared
+  concurrency group (their group keys can't statically match) — no-clobber + the idempotency
+  check are the cross-workflow protection.
+- **Failure classification.** Only the `lean-action` build step soft-fails. A breaking Lean
+  change or un-tagged `lean4-cli` keeps the run green and is reported; a broken token, API
+  outage, or failed upload turns the run red.
+- **Tracking issue.** One issue identified by the `lean-build-failure` label, body regenerated
+  each run, auto-closed when coverage is complete — no duplicate-issue spam.

--- a/specs/done/auto-release-lean-versions.md
+++ b/specs/done/auto-release-lean-versions.md
@@ -90,9 +90,10 @@ concurrency group serializes reruns.
 ### 4. Installer lookup — `tools/bash/install.sh`, `tools/python/install.py`
 
 When installing, the installer searches the releases for `probe-lean-<version>-<platform>.tar.gz`,
-requesting `per_page=100` (one call covers every probe-lean release for the foreseeable future)
-with an optional `GH_TOKEN`/`GITHUB_TOKEN`. If no prebuilt is found it falls back to a source
-build — so a toolchain without a published artifact still works, just slower.
+paginating newest-first (the watcher appends artifacts to the latest release over time, and
+superseded RCs live only on older releases) with an optional `GH_TOKEN`/`GITHUB_TOKEN`. If no
+prebuilt is found it falls back to a source build — so a toolchain without a published artifact
+still works, just slower.
 
 ## Things to note
 

--- a/tests/lean-versions/fixtures/oversized.json
+++ b/tests/lean-versions/fixtures/oversized.json
@@ -1,0 +1,1 @@
+[ { "tag_name": "v4.100000.0", "prerelease": false, "draft": false } ]

--- a/tests/lean-versions/fixtures/rate-limited.json
+++ b/tests/lean-versions/fixtures/rate-limited.json
@@ -1,0 +1,1 @@
+{ "message": "API rate limit exceeded", "documentation_url": "https://docs.github.com" }

--- a/tests/lean-versions/fixtures/releases.json
+++ b/tests/lean-versions/fixtures/releases.json
@@ -1,0 +1,18 @@
+[
+  { "tag_name": "v4.34.0",        "prerelease": true,  "draft": false },
+  { "tag_name": "v4.33.0",        "prerelease": false, "draft": true  },
+  { "tag_name": "v4.32.0-rc2",    "prerelease": true,  "draft": false },
+  { "tag_name": "v4.32.0-rc10",   "prerelease": true,  "draft": false },
+  { "tag_name": "v4.31.0",        "prerelease": false, "draft": false },
+  { "tag_name": "v4.30.0",        "prerelease": false, "draft": false },
+  { "tag_name": "v4.30.0-rc2",    "prerelease": true,  "draft": false },
+  { "tag_name": "v4.29.0",        "prerelease": false, "draft": false },
+  { "tag_name": "v4.29.0-rc8",    "prerelease": true,  "draft": false },
+  { "tag_name": "v4.29.0-rc4",    "prerelease": true,  "draft": false },
+  { "tag_name": "v4.28.0",        "prerelease": false, "draft": false },
+  { "tag_name": "v4.28.0-rc1",    "prerelease": true,  "draft": false },
+  { "tag_name": "v4.27.0",        "prerelease": false, "draft": false },
+  { "tag_name": "v4.20.0",        "prerelease": false, "draft": false },
+  { "tag_name": "nightly-2026-01-01", "prerelease": true, "draft": false },
+  { "tag_name": "v4.32",          "prerelease": false, "draft": false }
+]

--- a/tests/lean-versions/run.sh
+++ b/tests/lean-versions/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Tests for tools/lean-versions.sh (version-policy derivation).
+# Run from the probe-lean root directory: bash tests/lean-versions/run.sh
+#
+# Uses a fixed releases fixture so the policy is exercised without the network.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/../../tools/lean-versions.sh"
+FIXTURE="$HERE/fixtures/releases.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local name=$1 expected=$2 actual=$3
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Asserts the given command exits non-zero (a failure that must be surfaced).
+assert_fails() {
+    local name=$1; shift
+    if "$@" >/dev/null 2>&1; then
+        echo "  FAIL: $name (expected non-zero exit, got success)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "Testing version policy..."
+
+# Default floor (v4.28.0-rc1): stable lines collapse to their stable; the only
+# line without a stable (4.32.0) yields its latest RC (rc10 > rc2, numerically).
+assert_eq "default policy" \
+    $'v4.28.0\nv4.29.0\nv4.30.0\nv4.31.0\nv4.32.0-rc10' \
+    "$(LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT")"
+
+# JSON mode is a valid array in the same order.
+assert_eq "json mode" \
+    '["v4.28.0","v4.29.0","v4.30.0","v4.31.0","v4.32.0-rc10"]' \
+    "$(LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT" --json | jq -c .)"
+
+# Raising the floor to v4.30.0 drops 4.28/4.29.
+assert_eq "floor=v4.30.0" \
+    $'v4.30.0\nv4.31.0\nv4.32.0-rc10' \
+    "$(LEAN_VERSION_FLOOR=v4.30.0 LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT")"
+
+# A floor that is itself an RC is honored (v4.32.0-rc10 >= v4.32.0-rc2).
+assert_eq "floor=v4.32.0-rc2 (RC-valued floor)" \
+    'v4.32.0-rc10' \
+    "$(LEAN_VERSION_FLOOR=v4.32.0-rc2 LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT")"
+
+# A floor above everything yields zero tags: plain mode prints *no* lines (not a
+# blank line), JSON mode prints an empty array.
+assert_eq "empty plain output has no lines" "" \
+    "$(LEAN_VERSION_FLOOR=v999.0.0 LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT")"
+assert_eq "empty json output is []" "[]" \
+    "$(LEAN_VERSION_FLOOR=v999.0.0 LEAN_RELEASES_FILE="$FIXTURE" "$SCRIPT" --json | jq -c .)"
+
+# Failure paths must exit non-zero, not silently produce wrong output.
+assert_fails "non-array API response (rate limit) fails" \
+    env LEAN_RELEASES_FILE="$HERE/fixtures/rate-limited.json" "$SCRIPT"
+assert_fails "version component above the 5-digit bound fails" \
+    env LEAN_RELEASES_FILE="$HERE/fixtures/oversized.json" "$SCRIPT"
+assert_fails "--releases-file with no path fails" \
+    "$SCRIPT" --releases-file
+assert_fails "unknown argument fails" \
+    "$SCRIPT" --bogus
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tools/bash/install.sh
+++ b/tools/bash/install.sh
@@ -139,11 +139,26 @@ try_prebuilt_download() {
 
     echo "Checking for pre-built binary: probe-lean-${version}-${platform}..."
 
-    # Search across all releases for an artifact matching this Lean version + platform
-    local releases_url="https://api.github.com/repos/${GITHUB_REPO}/releases"
+    # Search the releases for an artifact matching this Lean version + platform.
+    # per_page=100 returns every release in one request (probe-lean is nowhere near
+    # 100 releases), and the current supported set is rebuilt into each release, so
+    # this reliably finds a supported version's artifact. An optional token avoids
+    # the low unauthenticated rate limit.
+    local releases_url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100"
+    local auth_header=""
+    if [ -n "${GH_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer ${GH_TOKEN}"
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+    fi
+    # Escape dots so the version matches literally. The trailing quote in the
+    # pattern anchors to the end of the asset name, so the .sha256 sidecar (which
+    # ends in .sha256, not the bare artifact) is never matched.
+    local artifact_re
+    artifact_re=$(printf '%s' "$artifact" | sed 's/\./\\./g')
     local download_url=""
-    download_url=$(curl -sL "$releases_url" 2>/dev/null \
-        | grep -o "\"browser_download_url\": \"[^\"]*${artifact}\"" \
+    download_url=$(curl -sL ${auth_header:+-H "$auth_header"} "$releases_url" 2>/dev/null \
+        | grep -o "\"browser_download_url\": \"[^\"]*${artifact_re}\"" \
         | head -1 \
         | sed 's/"browser_download_url": "//;s/"//') || true
 

--- a/tools/bash/install.sh
+++ b/tools/bash/install.sh
@@ -140,27 +140,43 @@ try_prebuilt_download() {
     echo "Checking for pre-built binary: probe-lean-${version}-${platform}..."
 
     # Search the releases for an artifact matching this Lean version + platform.
-    # per_page=100 returns every release in one request (probe-lean is nowhere near
-    # 100 releases), and the current supported set is rebuilt into each release, so
-    # this reliably finds a supported version's artifact. An optional token avoids
-    # the low unauthenticated rate limit.
-    local releases_url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100"
+    # Releases are paginated newest-first; the watcher appends artifacts to the
+    # latest release over time and superseded RCs live only on older releases, so
+    # walk the pages until found or exhausted. An optional token avoids the low
+    # unauthenticated rate limit.
+    local releases_url="https://api.github.com/repos/${GITHUB_REPO}/releases"
     local auth_header=""
     if [ -n "${GH_TOKEN:-}" ]; then
         auth_header="Authorization: Bearer ${GH_TOKEN}"
     elif [ -n "${GITHUB_TOKEN:-}" ]; then
         auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
     fi
-    # Escape dots so the version matches literally. The trailing quote in the
-    # pattern anchors to the end of the asset name, so the .sha256 sidecar (which
-    # ends in .sha256, not the bare artifact) is never matched.
+    # Escape dots so the version matches literally. The trailing quote anchors to
+    # the end of the asset name, so the .sha256 sidecar is never matched.
     local artifact_re
     artifact_re=$(printf '%s' "$artifact" | sed 's/\./\\./g')
-    local download_url=""
-    download_url=$(curl -sL ${auth_header:+-H "$auth_header"} "$releases_url" 2>/dev/null \
-        | grep -o "\"browser_download_url\": \"[^\"]*${artifact_re}\"" \
-        | head -1 \
-        | sed 's/"browser_download_url": "//;s/"//') || true
+    local download_url="" per_page=100 page=1 body trimmed
+    while [ "$page" -le 50 ]; do  # cap pages so we never loop unbounded
+        body=$(curl -sL ${auth_header:+-H "$auth_header"} \
+            "${releases_url}?per_page=${per_page}&page=${page}" 2>/dev/null) || break
+        download_url=$(printf '%s' "$body" \
+            | grep -o "\"browser_download_url\": \"[^\"]*${artifact_re}\"" \
+            | head -1 \
+            | sed 's/"browser_download_url": "//;s/"//') || true
+        [ -n "$download_url" ] && break
+        # Page on while the body is a non-empty JSON array; stop on the empty last
+        # page or on an error body (rate limit / auth) — falling back to source.
+        trimmed=$(printf '%s' "$body" | tr -d '[:space:]')
+        case "$trimmed" in
+            '[]')    break ;;
+            '['*']') page=$((page + 1)) ;;
+            *)
+                if printf '%s' "$body" | grep -q '"message"'; then
+                    echo "Note: GitHub API did not return releases (rate limit or auth?); set GH_TOKEN to raise the limit." >&2
+                fi
+                break ;;
+        esac
+    done
 
     if [ -z "$download_url" ]; then
         echo "No pre-built binary available, falling back to source build..."
@@ -236,7 +252,13 @@ build_from_source() {
         original_lakefile=$(cat lakefile.toml)
 
         echo "leanprover/lean4:$version" > lean-toolchain
-        sed -i'' -e "s/rev = \"v[^\"]*\"/rev = \"$version\"/" lakefile.toml
+        # Rewrite the rev of ONLY the lean4-cli dependency (portable awk; no sed -i).
+        awk -v ver="$version" '
+          /^[[:space:]]*\[\[/ { incli = 0 }
+          /git = ".*lean4-cli"/ { incli = 1 }
+          incli && /^[[:space:]]*rev[[:space:]]*=/ { sub(/"v[^"]*"/, "\"" ver "\"") }
+          { print }
+        ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
 
         rm -rf .lake lake-manifest.json
         echo "Removed .lake/ and lake-manifest.json"

--- a/tools/lean-versions.sh
+++ b/tools/lean-versions.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Derive the set of supported Lean toolchain versions from the leanprover/lean4
+# GitHub releases, applying the probe-lean support policy.
+#
+# Policy:
+#   - Consider non-draft releases whose tag is v<MAJOR>.<MINOR>.<PATCH> or
+#     v<MAJOR>.<MINOR>.<PATCH>-rc<N>, at or above the floor (LEAN_VERSION_FLOOR).
+#   - Output every *stable* tag (no -rc) >= floor, plus the *latest* RC of any
+#     version line that has not yet shipped a stable release.
+#   - RCs sort numerically (rc10 > rc2) and below their own stable
+#     (v4.29.0-rc8 < v4.29.0).
+#
+# Output is sorted ascending and deduplicated. Default is newline-separated;
+# --json emits a JSON array suitable for a GitHub Actions matrix.
+#
+# Sources of release data, in order of precedence:
+#   1. --releases-file PATH / $LEAN_RELEASES_FILE  (a JSON file; used by tests)
+#   2. `gh api --paginate`                          (handles auth + pagination)
+#   3. `curl` paginated against the public API
+set -euo pipefail
+
+REPO="leanprover/lean4"
+FLOOR="${LEAN_VERSION_FLOOR:-v4.28.0-rc1}"
+JSON=false
+RELEASES_FILE="${LEAN_RELEASES_FILE:-}"
+
+usage() {
+    cat <<EOF
+Usage: lean-versions.sh [--json] [--releases-file PATH]
+
+Print the Lean versions probe-lean supports, per the support policy.
+
+Options:
+  --json                 Emit a JSON array (for a GitHub Actions matrix)
+  --releases-file PATH   Read releases JSON from PATH instead of the GitHub API
+                         (the file must be the array returned by the releases API)
+  -h, --help             Show this help
+
+Environment:
+  LEAN_VERSION_FLOOR     Minimum version to consider (default: $FLOOR)
+  LEAN_RELEASES_FILE     Same as --releases-file
+  GH_TOKEN / GITHUB_TOKEN  Auth for the GitHub API (avoids rate limits)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --json) JSON=true ;;
+        --releases-file)
+            if [ $# -lt 2 ]; then
+                echo "Error: --releases-file requires a path argument" >&2
+                exit 2
+            fi
+            RELEASES_FILE="$2"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+fetch_releases() {
+    if [ -n "$RELEASES_FILE" ]; then
+        if [ ! -f "$RELEASES_FILE" ]; then
+            echo "Error: releases file not found: $RELEASES_FILE" >&2
+            exit 1
+        fi
+        cat "$RELEASES_FILE"
+        return
+    fi
+    if command -v gh >/dev/null 2>&1; then
+        # --paginate walks every page; --slurp wraps the pages as [[...],[...]],
+        # so `add // []` flattens them back into a single releases array (and an
+        # empty result stays an array rather than becoming null).
+        gh api --paginate --slurp "repos/${REPO}/releases?per_page=100" | jq 'add // []'
+        return
+    fi
+    # curl fallback: page until an empty array comes back. A failed request aborts
+    # loudly — never loop forever on a network error or rate limit.
+    local page=1 body all="[]"
+    while :; do
+        if ! body=$(curl -sSfL \
+            ${GH_TOKEN:+-H "Authorization: Bearer $GH_TOKEN"} \
+            ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+            "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}"); then
+            echo "Error: failed to fetch Lean releases (page $page) from the GitHub API" >&2
+            return 1
+        fi
+        if [ "$(printf '%s' "$body" | jq 'if type == "array" then length else error("not an array") end')" -eq 0 ]; then
+            break
+        fi
+        all=$(jq -s '.[0] + .[1]' <(printf '%s' "$all") <(printf '%s' "$body"))
+        page=$((page + 1))
+    done
+    printf '%s' "$all"
+}
+
+# Extract "<tag>\t<prerelease>" for non-draft releases. jq parses the JSON so we
+# never grep/sed structured data.
+extract() {
+    jq -r '.[] | select(.draft != true) | "\(.tag_name)\t\(.prerelease)"'
+}
+
+# Apply the policy. awk computes a numeric sort key per tag so RC/stable ordering
+# and the floor comparison are exact rather than lexical.
+apply_policy() {
+    awk -F'\t' -v floor="$FLOOR" '
+        function parse(tag,    t, rc, n, a) {
+            # Fills the P[] globals (maj/min/pat/isrc/rc); returns 0 on parse failure.
+            delete P
+            if (match(tag, /^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$/) == 0) return 0
+            t = substr(tag, 2)                     # strip leading v
+            rc = -1
+            if (t ~ /-rc[0-9]+$/) {
+                rc = t
+                sub(/^.*-rc/, "", rc)   # rc = the trailing number, as a string
+                rc = rc + 0             # coerce to a number
+                sub(/-rc[0-9]+$/, "", t)
+            }
+            n = split(t, a, ".")
+            if (n != 3) return 0
+            P["maj"] = a[1] + 0; P["min"] = a[2] + 0; P["pat"] = a[3] + 0
+            P["isrc"] = (rc >= 0) ? 1 : 0
+            P["rc"]   = (rc >= 0) ? rc : 0
+            # The fixed-width key below assumes each component fits in 5 digits.
+            # Reject anything larger so the lexical comparison can never be wrong.
+            if (P["maj"] > 99999 || P["min"] > 99999 || P["pat"] > 99999 || P["rc"] > 99999) {
+                print "Error: version component out of supported range (>99999): " tag > "/dev/stderr"
+                exit 4
+            }
+            return 1
+        }
+        function key() {
+            # stable (isrc=0) must outrank any rc of the same patch: slot = 1-isrc,
+            # so stable->1, rc->0. rc number is the final tiebreak. Every field is
+            # exactly 5 digits (bounded above), so lexical comparison is exact.
+            return sprintf("%05d%05d%05d%d%05d", P["maj"], P["min"], P["pat"], 1 - P["isrc"], P["rc"])
+        }
+        BEGIN {
+            if (parse(floor) == 0) { print "Error: invalid LEAN_VERSION_FLOOR: " floor > "/dev/stderr"; exit 3 }
+            floorkey = key()
+        }
+        {
+            tag = $1; pre = $2
+            if (parse(tag) == 0) next                       # malformed tag
+            # A prerelease that is not an -rc cannot be ordered; ignore it.
+            if (pre == "true" && P["isrc"] == 0) next
+            isrc = P["isrc"]; line = P["maj"] "." P["min"] "." P["pat"]; k = key()
+            if (k < floorkey) next                           # below floor
+            keyOf[tag] = k
+            if (isrc == 0) {
+                stable[line] = 1
+                emit[tag] = 1
+            } else if (k > bestRcKey[line]) {                # latest rc for the line
+                bestRcKey[line] = k
+                bestRcTag[line] = tag
+            }
+        }
+        END {
+            for (line in bestRcTag) {
+                if (!(line in stable)) emit[bestRcTag[line]] = 1
+            }
+            # Emit "key\ttag" so the caller can sort by key then strip it.
+            for (tag in emit) print keyOf[tag] "\t" tag
+        }
+    '
+}
+
+if ! releases_json="$(fetch_releases)"; then
+    echo "Error: could not retrieve Lean releases." >&2
+    exit 1
+fi
+
+# Rate-limit / error responses come back as a JSON object, not an array; fail
+# clearly rather than letting jq emit a cryptic type error downstream.
+if [ "$(printf '%s' "$releases_json" | jq -r 'type' 2>/dev/null)" != "array" ]; then
+    echo "Error: unexpected response from the GitHub releases API (not a JSON array)." >&2
+    echo "       This usually means a rate limit or auth problem — set GH_TOKEN." >&2
+    exit 1
+fi
+
+if ! selected="$(printf '%s' "$releases_json" | extract | apply_policy | sort -u | cut -f2)"; then
+    echo "Error: failed to compute the supported version list." >&2
+    exit 1
+fi
+
+if [ "$JSON" = true ]; then
+    printf '%s' "$selected" | jq -R -s 'split("\n") | map(select(length > 0))'
+elif [ -n "$selected" ]; then
+    printf '%s\n' "$selected"
+fi

--- a/tools/lean-versions.sh
+++ b/tools/lean-versions.sh
@@ -76,11 +76,12 @@ fetch_releases() {
     fi
     # curl fallback: page until an empty array comes back. A failed request aborts
     # loudly — never loop forever on a network error or rate limit.
+    # Resolve a single token so we never send two Authorization headers.
+    local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
     local page=1 body all="[]"
     while :; do
         if ! body=$(curl -sSfL \
-            ${GH_TOKEN:+-H "Authorization: Bearer $GH_TOKEN"} \
-            ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+            ${token:+-H "Authorization: Bearer $token"} \
             "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}"); then
             echo "Error: failed to fetch Lean releases (page $page) from the GitHub API" >&2
             return 1
@@ -142,7 +143,9 @@ apply_policy() {
         {
             tag = $1; pre = $2
             if (parse(tag) == 0) next                       # malformed tag
-            # A prerelease that is not an -rc cannot be ordered; ignore it.
+            # Skip a stable-shaped tag (no -rc) that GitHub flags as a prerelease:
+            # treat it as not-yet-released rather than emitting it as stable. RCs
+            # carry the -rc suffix (isrc==1) and are unaffected by this guard.
             if (pre == "true" && P["isrc"] == 0) next
             isrc = P["isrc"]; line = P["maj"] "." P["min"] "." P["pat"]; k = key()
             if (k < floorkey) next                           # below floor

--- a/tools/python/install.py
+++ b/tools/python/install.py
@@ -114,10 +114,10 @@ def try_prebuilt_download(version: str) -> bool:
     print(f"Checking for pre-built binary: probe-lean-{version}-{plat}...")
 
     # Search the releases for an artifact matching this Lean version + platform.
-    # per_page=100 returns every release in one request (probe-lean is nowhere near
-    # 100 releases), and the current supported set is rebuilt into each release, so
-    # this reliably finds a supported version's artifact. An optional token avoids
-    # the low unauthenticated rate limit.
+    # Releases are paginated newest-first; the watcher appends artifacts to the
+    # latest release over time and superseded RCs live only on older releases, so
+    # walk the pages until found or exhausted. An optional token avoids the low
+    # unauthenticated rate limit.
     try:
         releases_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
         headers = {}
@@ -125,16 +125,29 @@ def try_prebuilt_download(version: str) -> bool:
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        resp = httpx.get(releases_url, params={"per_page": 100}, headers=headers)
-        resp.raise_for_status()
-        releases = resp.json()
         download_url = None
-        for release in releases:
-            for asset in release.get("assets", []):
-                if asset["name"] == artifact_name:
-                    download_url = asset["browser_download_url"]
+        per_page = 100
+        for page in range(1, 51):  # cap pages so we never loop unbounded
+            resp = httpx.get(
+                releases_url, params={"per_page": per_page, "page": page}, headers=headers
+            )
+            resp.raise_for_status()
+            releases = resp.json()
+            if not isinstance(releases, list):
+                # A rate-limit / error response is a JSON object, not a list.
+                msg = releases.get("message") if isinstance(releases, dict) else releases
+                print(f"GitHub API did not return a release list ({msg}); set GH_TOKEN to raise the rate limit.")
+                break
+            if not releases:
+                break
+            for release in releases:
+                for asset in release.get("assets", []):
+                    if asset["name"] == artifact_name:
+                        download_url = asset["browser_download_url"]
+                        break
+                if download_url:
                     break
-            if download_url:
+            if download_url or len(releases) < per_page:
                 break
 
         if not download_url:
@@ -179,8 +192,8 @@ def try_prebuilt_download(version: str) -> bool:
                         else:
                             shutil.copy2(item, dest)
             return True
-    except Exception:
-        print("No pre-built binary available, falling back to source build...")
+    except Exception as e:
+        print(f"Pre-built lookup/download failed ({e}); falling back to source build...")
         return False
 
 
@@ -227,10 +240,19 @@ def update_toolchain(project_root: Path, version: str) -> str:
 
 
 def update_lakefile(project_root: Path, version: str) -> str:
-    """Update lakefile.toml Cli rev and return original content."""
+    """Update the lean4-cli dependency's rev in lakefile.toml; return original."""
     lakefile_path = project_root / "lakefile.toml"
     original = lakefile_path.read_text()
-    updated = re.sub(r'rev = "v[^"]+"', f'rev = "{version}"', original)
+    # Rewrite the rev of ONLY the lean4-cli dependency — match the lean4-cli git
+    # line and the rev line that follows it — so any future second pinned
+    # [[require]] with a v-rev is left untouched.
+    updated = re.sub(
+        r'(lean4-cli"[^\[]*?rev = ")v[^"]+(")',
+        rf"\g<1>{version}\g<2>",
+        original,
+        count=1,
+        flags=re.DOTALL,
+    )
     lakefile_path.write_text(updated)
     return original
 

--- a/tools/python/install.py
+++ b/tools/python/install.py
@@ -113,10 +113,21 @@ def try_prebuilt_download(version: str) -> bool:
 
     print(f"Checking for pre-built binary: probe-lean-{version}-{plat}...")
 
-    # Search across all releases for an artifact matching this Lean version + platform
+    # Search the releases for an artifact matching this Lean version + platform.
+    # per_page=100 returns every release in one request (probe-lean is nowhere near
+    # 100 releases), and the current supported set is rebuilt into each release, so
+    # this reliably finds a supported version's artifact. An optional token avoids
+    # the low unauthenticated rate limit.
     try:
         releases_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
-        releases = httpx.get(releases_url).json()
+        headers = {}
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        resp = httpx.get(releases_url, params={"per_page": 100}, headers=headers)
+        resp.raise_for_status()
+        releases = resp.json()
         download_url = None
         for release in releases:
             for asset in release.get("assets", []):


### PR DESCRIPTION
## What & why

Closes #38. probe-lean release artifacts are now generated **automatically** when
`leanprover/lean4` ships a new Lean version — no more hand-editing a hardcoded matrix and
cutting a release. A scheduled watcher builds probe-lean for any supported Lean version
missing from the latest release and appends the artifact; versions it can't yet build are
tracked in a single issue and retried.

Spec: `specs/done/auto-release-lean-versions.md`.

## How it works

`tools/lean-versions.sh` derives the supported Lean versions (every stable ≥ `v4.28.0-rc1`,
plus the latest RC of any unstabilised line). The **watcher** (`lean-watch.yml`, daily) builds
the versions missing from the latest release and appends them. `release.yml` (on a probe-lean
tag) rebuilds the full set from tagged source. The installers find a prebuilt by filename, else
build from source.

## Commit by commit

1. **`feat(ci): add Lean version policy script`** — `tools/lean-versions.sh` + fixture tests
   under `tests/lean-versions/`. The shared source of truth for which Lean versions are
   supported; `--json` feeds a GitHub Actions matrix.

2. **`fix(ci): derive release matrix dynamically and fix stale-manifest build`** — two things:
   - **Bug fix (essential):** `release.yml` rewrote `lakefile.toml`'s `Cli` rev but left the
     committed `lake-manifest.json` pinning `lean4-cli`, and used `sed -i''` (broken on macOS).
     Now removes `.lake` + `lake-manifest.json` after a portable `sed -i.bak`, adds a `--version`
     smoke test, per-version `continue-on-error`, a single `ensure-release` job, and a `verify`
     job. *(This likely means past macOS release artifacts were built against the wrong `Cli` —
     worth re-cutting.)*
   - **Add-on:** deriving the matrix live from the policy script instead of a hardcoded list.

3. **`feat(ci): add Lean watcher to auto-build artifacts for new versions`** — `lean-watch.yml`,
   the core of #38: daily, resolves the latest published release, builds missing
   `(version, platform)` artifacts, uploads with provenance (`BUILDINFO` + `.sha256`) and
   without clobbering, and maintains one `lean-build-failure` tracking issue.

4. **`fix(installer): fetch up to 100 releases when locating an artifact`** — installers
   requested only the first 30 releases; now `per_page=100` + optional `GH_TOKEN`. Keeps
   appended-across-releases artifacts findable.

5. **`docs: document automated release of artifacts for new Lean versions`** — README + USAGE
   (support policy, floor, auto-build, source-build fallback) and the implemented spec.

## Add-ons that can be dropped if reviewers prefer

- **Commit 4 entirely** — consumer-side robustness only; #38 is satisfied without it (the
  installer just falls back to source builds more often).
- **The matrix-de-hardcoding half of commit 2** — the watcher (commit 3) already covers new
  versions between bumps. The **manifest/`sed` bug fix in commit 2 should stay regardless.**

## Notes

- **Tradeoff:** both workflows derive the version set live, so a tag's exact artifact set isn't
  reproducible from the tag alone. Accepted — a single unbuildable version is skipped, and
  `verify` fails the run only if the release ends up with no artifacts.
- Pre-built platforms are `linux-x86_64` and `darwin-arm64` (what the runners yield); more
  arches are out of scope.
- Both the policy script and both workflows were reviewed adversarially (cross-model) at each
  step; failure paths, RC ordering, and upload/no-clobber semantics have explicit handling.
