### PR TITLE
fix(ci): re-resolve lean4-cli instead of deleting the manifest

### DIFF
--- a/.github/workflows/lean-watch.yml
+++ b/.github/workflows/lean-watch.yml
@@ -149,17 +149,31 @@ jobs:
             incli && /^[[:space:]]*rev[[:space:]]*=/ { sub(/"v[^"]*"/, "\"" ver "\"") }
             { print }
           ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
-          # Re-resolve Cli against the rewritten rev (issue #38).
-          rm -rf .lake lake-manifest.json
+          # Clear any stale build dir but KEEP lake-manifest.json — lean-action's
+          # build precondition needs it, and the Cli rev is re-resolved below.
+          rm -rf .lake
+
+      # lean-action installs the toolchain from lean-toolchain but does NOT build
+      # (build: false); we build ourselves below so we can re-resolve Cli first.
+      - uses: leanprover/lean-action@v1
+        if: steps.exists.outputs.present == 'false'
+        with:
+          build: false
+          test: false
 
       # A build failure is expected for some versions; tolerate it and let the
       # report job record it. The steps below run only on a clean build.
-      - uses: leanprover/lean-action@v1
+      - name: Re-resolve Cli and build
         id: build
         if: steps.exists.outputs.present == 'false'
         continue-on-error: true
-        with:
-          test: false
+        run: |
+          # The committed lake-manifest.json pins Cli to an unrelated rev; without
+          # this, `lake build` would materialize that stale rev and build the WRONG
+          # lean4-cli. `lake update Cli` regenerates the manifest for the rewritten
+          # rev; --keep-toolchain stops it touching the toolchain lean-action set up.
+          lake --keep-toolchain update Cli
+          lake build
 
       - name: Report unbuildable version
         if: steps.exists.outputs.present == 'false' && steps.build.outcome != 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,20 +107,31 @@ jobs:
             incli && /^[[:space:]]*rev[[:space:]]*=/ { sub(/"v[^"]*"/, "\"" ver "\"") }
             { print }
           ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
-          # Drop the committed manifest and build dir so Lake re-resolves Cli
-          # against the rewritten rev — otherwise the pinned manifest wins and the
-          # build silently uses the wrong lean4-cli (issue #38).
-          rm -rf .lake lake-manifest.json
+          # Clear any stale build dir but KEEP lake-manifest.json — lean-action's
+          # build precondition needs it, and the Cli rev is re-resolved below.
+          rm -rf .lake
+
+      # lean-action installs the toolchain from lean-toolchain but does NOT build
+      # (build: false); we build ourselves below so we can re-resolve Cli first.
+      - uses: leanprover/lean-action@v1
+        with:
+          build: false
+          test: false
 
       # A build failure here is expected for some Lean versions (breaking upstream
       # changes, or lean4-cli not yet tagged). Tolerate it per-version so one bad
       # version cannot fail the whole release; the steps below run only on success,
       # and the `verify` job fails the run if *nothing* built.
-      - uses: leanprover/lean-action@v1
+      - name: Re-resolve Cli and build
         id: build
         continue-on-error: true
-        with:
-          test: false
+        run: |
+          # The committed lake-manifest.json pins Cli to an unrelated rev; without
+          # this, `lake build` would materialize that stale rev and build the WRONG
+          # lean4-cli. `lake update Cli` regenerates the manifest for the rewritten
+          # rev; --keep-toolchain stops it touching the toolchain lean-action set up.
+          lake --keep-toolchain update Cli
+          lake build
 
       - name: Report unbuildable version
         if: steps.build.outcome != 'success'

--- a/tools/bash/install.sh
+++ b/tools/bash/install.sh
@@ -247,9 +247,10 @@ build_from_source() {
     else
         echo "Switching from $current_version to $version..."
 
-        local original_toolchain original_lakefile
+        local original_toolchain original_lakefile original_manifest
         original_toolchain=$(cat lean-toolchain)
         original_lakefile=$(cat lakefile.toml)
+        original_manifest=$(cat lake-manifest.json 2>/dev/null || true)
 
         echo "leanprover/lean4:$version" > lean-toolchain
         # Rewrite the rev of ONLY the lean4-cli dependency (portable awk; no sed -i).
@@ -260,15 +261,22 @@ build_from_source() {
           { print }
         ' lakefile.toml > lakefile.toml.tmp && mv lakefile.toml.tmp lakefile.toml
 
-        rm -rf .lake lake-manifest.json
-        echo "Removed .lake/ and lake-manifest.json"
+        rm -rf .lake
+        echo "Cleared .lake/"
 
+        # Re-resolve Cli for the rewritten rev — the committed manifest pins an
+        # unrelated rev, so `lake build` alone would build the wrong lean4-cli.
+        # --keep-toolchain leaves the toolchain lean/elan selected untouched.
         local build_ok=true
-        lake build || build_ok=false
+        lake --keep-toolchain update Cli && lake build || build_ok=false
 
         echo "$original_toolchain" > lean-toolchain
         echo "$original_lakefile" > lakefile.toml
-        echo "Restored lean-toolchain and lakefile.toml"
+        # Restore the manifest too, so an in-repo install leaves the tree clean.
+        if [ -n "$original_manifest" ]; then
+            printf '%s\n' "$original_manifest" > lake-manifest.json
+        fi
+        echo "Restored lean-toolchain, lakefile.toml, and lake-manifest.json"
 
         if [ "$build_ok" = false ]; then
             echo "Build failed" >&2


### PR DESCRIPTION
## Problem

The Lean watcher's first real run ([run 28488117173](https://github.com/Beneficial-AI-Foundation/probe-lean/actions/runs/28488117173)) correctly detected three Lean versions missing artifacts (`v4.28.1`, `v4.29.1`, `v4.32.0-rc1`), but **every build failed** at the `lean-action` step:

```
##[error]No lake-manifest.json found. Run lake update to generate manifest
```

The run stayed green (fail-soft) and filed tracking issue #56, but no artifacts were produced.

## Root cause

Introduced in #53: the build step did `rm -rf .lake lake-manifest.json` before `lean-action`. Two problems:

1. **Direct failure:** with the manifest deleted, `lean-action`'s build precondition errors out (the message above is `lean-action`'s, not raw Lake's).
2. **The deletion was the wrong cure anyway.** `lake build` does **not** re-resolve a committed manifest — it materializes the manifest's *pinned* rev and only *warns* if the lakefile rev differs. So keeping the committed manifest builds the **wrong `lean4-cli`**. (Confirmed against the Lake source: `Load/Resolve.lean` + `Load/Materialize.lean`.)

This is a real latent bug — the committed manifest on `main` pins `Cli inputRev v4.30.0-rc2` while the lakefile/toolchain are `v4.28.0-rc1`, so builds already used a mismatched `lean4-cli` (it happened to compile).

## Fix

Keep the manifest and **re-resolve `Cli` explicitly**, in both workflows:

- `lean-action` with `build: false` (installs the toolchain, no build)
- then `lake --keep-toolchain update Cli && lake build` — regenerates the manifest for the rewritten rev, so the correct `lean4-cli` is built.

Same fix in `tools/bash/install.sh`'s source-build path, plus restore `lake-manifest.json` after building so an in-repo install leaves the tree clean — **closes #55**.

## Verification

Locally reproduced the inconsistency (lakefile `v4.28.0-rc1` vs manifest `v4.30.0-rc2`) and confirmed `lake --keep-toolchain update Cli` rewrites the manifest to `v4.28.0-rc1` before building. End-to-end proof is CI: after review I'll run the watcher from this branch — it should build the three missing versions, upload them to `v0.9.4`, and auto-close #56.

## Not included

The committed manifest on `main` is itself inconsistent, but regenerating it correctly requires the matching toolchain (my local lake produced a format downgrade), so that hygiene cleanup is left out of this CI fix.