### PR TITLE
feat(extract): distinguish type-member deps from orphans in enrich warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `extract` enrichment now separates benign references to constructors/fields of
+  extracted types (`inductive`/`structure`/`class`) from genuine orphan
+  dependencies. Such type-member references are summarised in a single note
+  instead of emitting one "not found in atom map" warning each, so real missing
+  dependencies are no longer drowned out. Genuine orphans (e.g. instance
+  projections, trait-impl references) are still reported individually. New
+  `partitionMissingDeps` helper in `ProbeLean/Transitive.lean`.
+
 ## [0.9.5] - 2026-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-17
+
 ### Changed
 
 - `extract` enrichment now separates benign references to constructors/fields of

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -306,8 +306,14 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
   else do
     IO.println "=== Enrich ==="
     let (enriched, transitive, local_, missingDeps) := enrichTransitiveVerification unifiedAtoms
-    for dep in missingDeps do
+    -- Only surface genuine orphans. References to constructors/fields of an
+    -- extracted type (inductive/structure/class) are benign and collapsed into
+    -- a single note so real gaps are not lost in the noise.
+    let (orphans, typeMemberCount) := partitionMissingDeps unifiedAtoms missingDeps
+    for dep in orphans do
       IO.eprintln s!"Warning: dependency \"{dep}\" not found in atom map (treated as trusted)"
+    if typeMemberCount > 0 then
+      IO.eprintln s!"Note: {typeMemberCount} reference(s) to constructors/fields of extracted types treated as trusted"
     let notVerified := enriched.size - transitive - local_
     IO.println s!"Transitively verified: {transitive} | Locally verified: {local_} | Not verified: {notVerified}"
     pure enriched

--- a/ProbeLean/Transitive.lean
+++ b/ProbeLean/Transitive.lean
@@ -19,6 +19,52 @@ private def isContaminationSource (status : Option WebVerificationStatus) : Bool
   | some .unverified | some .failed => true
   | _ => false
 
+/-- Kinds whose members (enum constructors, struct fields/projections, class
+    fields) are referenced as dependencies but are not emitted as standalone
+    atoms. -/
+def isTypeDefinition (kind : DeclKind) : Bool :=
+  match kind with
+  | .inductive | .structure | .class => true
+  | _ => false
+
+/-- The parent path segment of a dotted code-name: everything before the final
+    `.` (e.g. `probe:spqr.Error.StateDecode` → `probe:spqr.Error`). `none` when
+    the name has no `.` separator. -/
+def parentName (dep : String) : Option String :=
+  let parts := dep.splitOn "."
+  if parts.length ≤ 1 then none
+  else some (String.intercalate "." parts.dropLast)
+
+/-- Partition missing-dependency names into genuine orphans vs. benign
+    references to members of an extracted type. A dep `Foo.Bar` is a benign
+    "type member" when `Foo` names an extracted `inductive`/`structure`/`class`
+    atom: its constructors/fields/projections are not emitted as their own
+    atoms, carry no verification status, and treating them as trusted is
+    correct — so they should not be surfaced. Everything else (a reference whose
+    parent is absent, or whose parent is a `def`/`theorem`/etc.) is a genuine
+    orphan worth reporting.
+
+    Returns `(orphans, typeMemberCount)`. `orphans` preserves the sorted,
+    deduplicated order of `missingDeps` (P14). -/
+def partitionMissingDeps (atoms : Array UnifiedAtom) (missingDeps : Array String)
+    : Array String × Nat := Id.run do
+  let mut typeDefs : RBTree String compare := .empty
+  for atom in atoms do
+    if isTypeDefinition atom.kind then
+      typeDefs := typeDefs.insert atom.name
+  let mut orphans : Array String := #[]
+  let mut typeMemberCount : Nat := 0
+  for dep in missingDeps do
+    let isMember :=
+      match parentName dep with
+      | some parent => typeDefs.contains parent
+      | none => false
+    if isMember then
+      typeMemberCount := typeMemberCount + 1
+    else
+      orphans := orphans.push dep
+  (orphans, typeMemberCount)
+
 /-- Enrich verification status through the dependency graph using
     reverse-BFS contamination.
 

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.9.5"
+def version : String := "0.9.6"
 
 end ProbeLean

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -3346,6 +3346,49 @@ def testTransitiveVerificationProperties (result : TestResult) : IO TestResult :
 
   return result
 
+def testPartitionMissingDeps (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing partitionMissingDeps..."
+
+  -- An enum-variant reference whose parent is an extracted inductive is a
+  -- benign type member (suppressed); a genuine orphan is reported.
+  let enumAtom := { mkUnified "probe:M.Error" #[] none with kind := .inductive }
+  let caller := mkUnified "probe:M.f" #["probe:M.Error.StateDecode", "probe:totally_unknown"]
+    (some .verified)
+  let (orphans, memberCount) :=
+    partitionMissingDeps #[enumAtom, caller]
+      #["probe:M.Error.StateDecode", "probe:totally_unknown"]
+  result ← test "enum variant ref suppressed as type member" (memberCount == 1) result
+  result ← test "genuine orphan still reported"
+    (orphans == #["probe:totally_unknown"]) result
+
+  -- Struct field reference whose parent is an extracted structure is suppressed.
+  let structAtom := { mkUnified "probe:M.S" #[] none with kind := .structure }
+  let (orphans2, memberCount2) :=
+    partitionMissingDeps #[structAtom] #["probe:M.S.field"]
+  result ← test "struct field ref suppressed" (memberCount2 == 1 && orphans2.isEmpty) result
+
+  -- Class field reference whose parent is an extracted class is suppressed.
+  let classAtom := { mkUnified "probe:M.C" #[] none with kind := .class }
+  let (_, memberCount3) := partitionMissingDeps #[classAtom] #["probe:M.C.proj"]
+  result ← test "class field ref suppressed" (memberCount3 == 1) result
+
+  -- A member of a non-type parent (a `def`) is a genuine orphan, still reported.
+  let defAtom := mkUnified "probe:M.g" #[] none
+  let (orphans4, memberCount4) :=
+    partitionMissingDeps #[defAtom] #["probe:M.g.inner"]
+  result ← test "member of non-type parent still reported"
+    (memberCount4 == 0 && orphans4 == #["probe:M.g.inner"]) result
+
+  -- A dep whose parent is absent from the map is a genuine orphan.
+  let (orphans5, memberCount5) :=
+    partitionMissingDeps #[] #["probe:Unknown.Variant"]
+  result ← test "absent-parent ref reported as orphan"
+    (memberCount5 == 0 && orphans5 == #["probe:Unknown.Variant"]) result
+
+  return result
+
 def testTransitiveVerificationJson (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -3451,6 +3494,7 @@ def main : IO UInt32 := do
   result ← testTransitiveVerificationTrust result
   result ← testTransitiveVerificationGraph result
   result ← testTransitiveVerificationProperties result
+  result ← testPartitionMissingDeps result
   result ← testTransitiveVerificationJson result
 
   IO.println ""

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.9.5"
+version = "0.9.6"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
## Summary
- New `partitionMissingDeps` helper in `ProbeLean/Transitive.lean` classifies missing-dependency references.
- References whose parent is an extracted `inductive`/`structure`/`class` atom are benign **type members** (enum constructors, struct fields, class projections) and are collapsed into a single `Note:` line.
- **Genuine orphans** (e.g. `Inhabited` instance projections, `Iterator` trait-impl references) are still reported individually.

## Why
`extract`'s enrichment step reimplements probe's transitive-verification pass in Lean and emitted one `Warning: dependency "..." not found in atom map` per missing reference. On real projects (SparsePostQuantumRatchet) this was ~90+ warnings, almost all enum-constructor / struct-field references to types that *are* extracted — drowning out the few genuinely missing dependencies. Mirrors the companion change in `probe` (`enrich_verification_status`).

## Test plan
- [x] `lake build`
- [x] `lake exe tests` (592 tests; 6 new covering enum-variant / struct-field / class-field suppression and orphan reporting)

Made with [Cursor](https://cursor.com)