### PR TITLE
feat!: bump schema-version to 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped schema-version to 3.0 (breaking) to align with the ecosystem-wide major
+  bump for the is-disabled→untracked atom field rename.
+
 ## [0.9.6] - 2026-07-17
 
 ### Changed

--- a/ProbeLean/Loader.lean
+++ b/ProbeLean/Loader.lean
@@ -1,6 +1,6 @@
 /-
   Shared loading functions for probe-lean output files.
-  Handles both bare-dict (Schema 1.x) and enveloped (Schema 2.0) formats.
+  Handles both bare-dict (Schema 1.x) and enveloped (Schema 3.0) formats.
 -/
 import Lean
 import ProbeLean.Types
@@ -9,7 +9,7 @@ namespace ProbeLean
 
 open Lean
 
-/-- Extract the atom data from JSON, unwrapping the Schema 2.0 envelope if present. -/
+/-- Extract the atom data from JSON, unwrapping the Schema 3.0 envelope if present. -/
 def unwrapEnvelope (json : Json) : Json :=
   match json.getObjVal? "schema", json.getObjVal? "data" with
   | .ok (.str _), .ok data => data

--- a/ProbeLean/Metadata.lean
+++ b/ProbeLean/Metadata.lean
@@ -1,5 +1,5 @@
 /-
-  Schema 2.0 metadata gathering and output path construction.
+  Schema 3.0 metadata gathering and output path construction.
   Reads git info and lakefile to populate envelope fields.
   Callers construct typed `Envelope α` directly rather than using generic wrappers.
 -/

--- a/ProbeLean/Types.lean
+++ b/ProbeLean/Types.lean
@@ -1,6 +1,6 @@
 /-
   Types for probe-lean output.
-  Defines atoms, specs, proofs, stubs, and Schema 2.0 envelope types
+  Defines atoms, specs, proofs, stubs, and Schema 3.0 envelope types
   with JSON serialization matching the probe interchange spec.
 -/
 import Lean.Data.Json
@@ -20,16 +20,16 @@ namespace Constants
   def mapsDir : String := "maps"
   def toolName : String := "probe-lean"
   def toolVersion : String := ProbeLean.version
-  def schemaVersion : String := "2.0"
+  def schemaVersion : String := "3.0"
   def schemaExtract : String := "probe-lean/extract"
   def schemaView : String := "probe-lean/viewify"
 end Constants
 
 -- ============================================================
--- Schema 2.0 envelope types
+-- Schema 3.0 envelope types
 -- ============================================================
 
-/-- Tool metadata for the Schema 2.0 envelope -/
+/-- Tool metadata for the Schema 3.0 envelope -/
 structure ToolInfo where
   name : String := Constants.toolName
   version : String := Constants.toolVersion
@@ -50,7 +50,7 @@ instance : Lean.FromJson ToolInfo where
     let command ← json.getObjValAs? String "command"
     return { name, version, command }
 
-/-- Source metadata for the Schema 2.0 envelope.
+/-- Source metadata for the Schema 3.0 envelope.
     `repo` and `commit` are non-optional String (empty when unavailable)
     to conform to the probe repo JSON Schema which declares them required. -/
 structure SourceInfo where
@@ -88,7 +88,7 @@ instance : Lean.FromJson SourceInfo where
     let sourceClass ← json.getObjValAs? (Option String) "class" <|> pure none
     return { repo, commit, language, package, packageVersion, sourceClass }
 
-/-- Typed envelope wrapper for all Schema 2.0 outputs -/
+/-- Typed envelope wrapper for all Schema 3.0 outputs -/
 structure Envelope (α : Type) where
   schema : String
   schemaVersion : String := Constants.schemaVersion

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.9.6"
+def version : String := "0.10.0"
 
 end ProbeLean

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Analyze Lean 4 projects: extract dependency graphs with verification status and spec relationships.
 
-`probe-lean` walks the Lean environment of a built project and produces structured JSON describing every declaration, its dependencies (type and term), source locations, sorry-based verification status, and spec relationships. Output follows the Schema 2.0 envelope format; see [docs/SCHEMA.md](docs/SCHEMA.md) for the full specification.
+`probe-lean` walks the Lean environment of a built project and produces structured JSON describing every declaration, its dependencies (type and term), source locations, sorry-based verification status, and spec relationships. Output follows the Schema 3.0 envelope format; see [docs/SCHEMA.md](docs/SCHEMA.md) for the full specification.
 
 ## Prerequisites
 
@@ -163,7 +163,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "2.0",
+  "schema-version": "3.0",
   "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
@@ -209,7 +209,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
     4. Sole spec — if a definition has exactly one spec theorem, it is used as primary spec
 5. **Verify** -- parses sorry warnings from build output to determine verification status (shallow: checks only the declaration's own body, not its dependencies); axioms, declarations tagged `@[externally_verified]`, and non-theorem `*External.lean` declarations are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"externally_verified"`, or `"external"`) for trust-base classification; theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal verification status; declarations without source location (kernel-synthesized) are filtered from output (skippable via `--skip-verify`)
 6. **Enrich** -- upgrades `"verified"` atoms to `"transitively-verified"` when all transitive dependencies are verified or trusted, using reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`; skippable via `--skip-enrich`)
-7. **Schema 2.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
+7. **Schema 3.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
 
 ## How probe-lean decides what to analyze
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -55,7 +55,7 @@ extract output:
 
 | Test function | Checks | What it validates |
 |---------------|--------|-------------------|
-| `testExampleJsonEnvelopeStructure` | 8 | Schema is `probe-lean/extract`, version `2.0`, non-empty timestamp, tool name/command, source package/language, data object present |
+| `testExampleJsonEnvelopeStructure` | 8 | Schema is `probe-lean/extract`, version `3.0`, non-empty timestamp, tool name/command, source package/language, data object present |
 | `testExampleJsonLoadAtoms` | 4 | `loadAtoms` succeeds, >1000 atoms, all keys start with `probe:`, all atoms have language `"lean"` |
 | `testExampleJsonAtomRequiredFields` | 8 | Non-empty `display-name`, `code-module`, `code-path`; valid `DeclKind`; has `def`, `theorem`, and `projection` atoms; all atoms have source location |
 | `testExampleJsonVerificationStatus` | 6 | All atoms have valid `verification-status` (verified/unverified/failed/trusted); at least some `"verified"` and `"trusted"`; all trusted have valid `trusted-reason`; non-trusted have no `trusted-reason` |

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -32,7 +32,7 @@ def testConstants (result : TestResult) : IO TestResult := do
   result ← test "mapsDir" (Constants.mapsDir == "maps") result
   result ← test "toolName" (Constants.toolName == "probe-lean") result
   result ← test "toolVersion" (Constants.toolVersion == ProbeLean.version) result
-  result ← test "schemaVersion" (Constants.schemaVersion == "2.0") result
+  result ← test "schemaVersion" (Constants.schemaVersion == "3.0") result
   result ← test "schemaExtract" (Constants.schemaExtract == "probe-lean/extract") result
   result ← test "schemaView" (Constants.schemaView == "probe-lean/viewify") result
   return result
@@ -200,7 +200,7 @@ def testTypeJsonSerialization (result : TestResult) : IO TestResult := do
   let hasSchema := match envJson.getObjValAs? String "schema" with
     | .ok "probe-lean/extract" => true | _ => false
   let hasSchemaVer := match envJson.getObjValAs? String "schema-version" with
-    | .ok "2.0" => true | _ => false
+    | .ok "3.0" => true | _ => false
   let hasTool := match envJson.getObjVal? "tool" with
     | .ok _ => true | _ => false
   let hasSource := match envJson.getObjVal? "source" with
@@ -1602,7 +1602,7 @@ def testEnvelopeAwareLoading (result : TestResult) : IO TestResult := do
   ]
   let enveloped := Lean.Json.mkObj [
     ("schema", Lean.toJson "probe-lean/extract"),
-    ("schema-version", Lean.toJson "2.0"),
+    ("schema-version", Lean.toJson "3.0"),
     ("data", bareDict)
   ]
   let bareStr := Lean.Json.pretty bareDict
@@ -1658,7 +1658,7 @@ def testEnvelopeAwareLoading (result : TestResult) : IO TestResult := do
   IO.println "Testing unwrapEnvelope accepts any schema prefix..."
   let foreignEnvelope := Lean.Json.mkObj [
     ("schema", Lean.toJson "probe-verus/atoms"),
-    ("schema-version", Lean.toJson "2.0"),
+    ("schema-version", Lean.toJson "3.0"),
     ("data", bareDict)
   ]
   let foreignUnwrapped := match Lean.Json.parse (Lean.Json.pretty foreignEnvelope) with
@@ -2211,8 +2211,8 @@ def testExampleJsonEnvelopeStructure (result : TestResult) : IO TestResult := do
       | .ok "probe-lean/extract" => true | _ => false
     result ← test "envelope schema is probe-lean/extract" schemaOk result
     let versionOk := match json.getObjValAs? String "schema-version" with
-      | .ok "2.0" => true | _ => false
-    result ← test "envelope schema-version is 2.0" versionOk result
+      | .ok "3.0" => true | _ => false
+    result ← test "envelope schema-version is 3.0" versionOk result
     let hasTimestamp := match json.getObjValAs? String "timestamp" with
       | .ok s => !s.isEmpty | _ => false
     result ← test "envelope has non-empty timestamp" hasTimestamp result

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,21 +1,21 @@
-# Schema 2.0: Lean Instantiation
+# Schema 3.0: Lean Instantiation
 
-Version: 2.0
+Version: 3.0
 Date: 2026-05-22
 Parent document: [probes/docs/envelope-rationale.md](https://github.com/Beneficial-AI-Foundation/probe/blob/main/docs/envelope-rationale.md)
 
-This document defines the Lean-specific details for Schema 2.0 as produced by `probe-lean`.
+This document defines the Lean-specific details for Schema 3.0 as produced by `probe-lean`.
 It instantiates the generic envelope and atom schema from the parent document with Lean
 declaration kinds, code-name URIs, versioning, and field mappings.
 
 ## Envelope Example
 
-A complete probe-lean extract output with the Schema 2.0 envelope:
+A complete probe-lean extract output with the Schema 3.0 envelope:
 
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "2.0",
+  "schema-version": "3.0",
   "tool": {
     "name": "probe-lean",
     "version": "0.4.5",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -264,12 +264,12 @@ probe-lean extract ./my-project -m MyProject.Core
 
 For the complete JSON schema specification, see [SCHEMA.md](SCHEMA.md).
 
-The `extract` command produces a JSON file wrapped in a Schema 2.0 metadata envelope:
+The `extract` command produces a JSON file wrapped in a Schema 3.0 metadata envelope:
 
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "2.0",
+  "schema-version": "3.0",
   "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",

--- a/examples/lean_Curve25519Dalek_0.1.0.json
+++ b/examples/lean_Curve25519Dalek_0.1.0.json
@@ -12,7 +12,7 @@
   "language": "lean",
   "commit": "df8fb499e1cee086c23de96cba57622326863c8e"
  },
- "schema-version": "2.0",
+ "schema-version": "3.0",
  "schema": "probe-lean/extract",
  "data": {
   "probe:Aeneas.Std.U64.shiftRight_51": {

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.9.6"
+version = "0.10.0"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
Bumps the emitted `schema-version` to the ecosystem-unified `3.0` (major), aligning with the breaking `is-disabled`→`untracked` atom-field rename (Beneficial-AI-Foundation/probe#42). probe-lean does not carry that field; this is the schema-version bump only.

Version 0.9.6 → 0.10.0. `lake build tests` → 592 passed, 0 failed.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)