### PR TITLE
feat(extract): hide Lean-generated code soundly + add check-axioms audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `check-axioms` command: audits a project and reports every declaration (of those
+  `extract` emits as atoms) whose transitive closure reaches the `sorryAx` axiom —
+  the kernel ground truth for "rests on a `sorry`", independent of the extract
+  dependency graph. Supports `-m`/`-l` scoping. New `ProbeLean/AxiomCheck.lean`.
+
 ### Changed
 
 - Bumped schema-version to 3.0 (breaking) to align with the ecosystem-wide major
   bump for the is-disabled→untracked atom field rename.
+- `extract` now auto-flags Lean-generated code — `deriving`-generated instance
+  clusters and structure/class projections — as `is-hidden` + `is-extraction-artifact`,
+  so `viewify` and the web UI omit it from the presented graph. These atoms remain in
+  the dependency graph, so transitive-verification stays sound. **Note:** `viewify`
+  output no longer includes projection or derived-instance nodes.
+- `markAtomFlags` now ORs the `is-hidden` / `is-extraction-artifact` flags with any
+  already set, so config-based flagging adds to (rather than overwrites) the automatic
+  detection above.
 
 ## [0.9.6] - 2026-07-17
 

--- a/ProbeLean.lean
+++ b/ProbeLean.lean
@@ -3,12 +3,14 @@ import ProbeLean.NixEnv
 import ProbeLean.Environment
 import ProbeLean.Coimport
 import ProbeLean.Analysis
+import ProbeLean.AxiomCheck
 import ProbeLean.Loader
 import ProbeLean.Metadata
 import ProbeLean.Atomize
 import ProbeLean.VerifyInternal
 import ProbeLean.Transitive
 import ProbeLean.Extract
+import ProbeLean.CheckAxioms
 import ProbeLean.View
 import ProbeLean.Classify.Catalogue
 import ProbeLean.Classify.SecurityProtocol

--- a/ProbeLean/Analysis.lean
+++ b/ProbeLean/Analysis.lean
@@ -353,6 +353,53 @@ def analyzeDecl (env : Environment) (name : Name) (info : ConstantInfo)
     codomainShape := classifyCodomain gameHeads info.type,
     classAttributes := detectClassAttrs env name }
 
+/-- `outer` covers `inner`'s line range, sharing boundaries allowed but not the
+identical range. Ranges are line-only (no columns), so a member reported on the
+type's last line counts as covered — which is what we want for a `deriving`
+clause that Lean collapses onto the type's final line. -/
+def coversRange (outer inner : CodeTextInfo) : Bool :=
+  decide (outer.linesStart ≤ inner.linesStart) &&
+  decide (inner.linesEnd ≤ outer.linesEnd) &&
+  !(inner.linesStart == outer.linesStart && inner.linesEnd == outer.linesEnd)
+
+/-- Names of `deriving`-generated instance clusters (`instDecidableEq…`,
+`instRepr…`, plus their backing `.decEq`/`.repr`/… members).
+
+A member qualifies when it is an auto-named `instance` (or a member whose
+name-prefix is such an instance) whose source range sits inside an
+`inductive`/`structure`/`class` in the same module — i.e. inside that type's
+`deriving` clause. Hand-written top-level instances, structure projections, and
+proof-fields are excluded.
+
+These names are marked `isExtractionArtifact` (see `markAtomFlags`), **not
+dropped**: the atoms stay in the dependency graph so transitive-verification
+contamination still flows through them, while `viewify` filters them from the
+web UI. Dropping them would be unsound — a surviving theorem depending on such an
+instance would lose the contamination path through it and could be falsely
+upgraded to `transitively-verified`. -/
+def derivedInstanceClusterNames (decls : Array DeclInfo) : Std.HashSet Name := Id.run do
+  let typeDefs := decls.filter fun d =>
+    (d.kind == .inductive || d.kind == .structure || d.kind == .class) && d.sourceInfo.isSome
+  let insideTypeDef : DeclInfo → Bool := fun d =>
+    match d.sourceInfo with
+    | none => false
+    | some r => typeDefs.any fun t =>
+        t.moduleName == d.moduleName &&
+        (match t.sourceInfo with
+         | some tr => coversRange tr r
+         | none => false)
+  -- Auto-named instances synthesized inside a type definition = deriving output.
+  let mut derived : Std.HashSet Name := {}
+  for d in decls do
+    if d.kind == .instance && insideTypeDef d then
+      derived := derived.insert d.name
+  -- Backing members of a derived instance (e.g. `instReprPoint.repr`).
+  let mut result := derived
+  for d in decls do
+    if insideTypeDef d && derived.contains d.name.getPrefix then
+      result := result.insert d.name
+  return result
+
 /-- Get all project declarations from an environment. `gameHeads` is threaded to
 `analyzeDecl` for `codomainShape` (default placeholder until Commit 3's catalogue). -/
 def getProjectDecls (env : Environment) (projectModules : Array Name)

--- a/ProbeLean/Atomize.lean
+++ b/ProbeLean/Atomize.lean
@@ -83,8 +83,10 @@ def hasAnySuffix (name : String) (suffixes : Array String) : Bool :=
 def markAtomFlags (atoms : Array Atom) (hiddenList : Array String) (artifactSuffixes : Array String) (ignoredList : Array String) : Array Atom :=
   atoms.map fun atom =>
     let nameWithoutPrefix := stripProbePrefix atom.name
-    let isHidden := hiddenList.contains nameWithoutPrefix
-    let isExtractionArtifact := hasAnySuffix nameWithoutPrefix artifactSuffixes
+    -- OR with any flag already set (e.g. auto-detected generated code), so config
+    -- adds to rather than overwrites automatic detection.
+    let isHidden := atom.isHidden || hiddenList.contains nameWithoutPrefix
+    let isExtractionArtifact := atom.isExtractionArtifact || hasAnySuffix nameWithoutPrefix artifactSuffixes
     let isIgnored := ignoredList.contains nameWithoutPrefix
     { atom with isHidden := isHidden, isExtractionArtifact := isExtractionArtifact, isIgnored := isIgnored }
 
@@ -219,15 +221,12 @@ def classifyProject (env : Environment) (decls : Array DeclInfo)
   IO.println s!"Classified {classifications.size} declarations"
   return classifications
 
-/-- Run analysis via lake env to get correct search paths.
-    Returns the atoms, the effective project class (`none` when no class is
-    detected), and the per-declaration classifications (empty when no class).
-    The class is resolved here — where both the environment and the project path
-    are available. Precedence: `classOverride` (from `--class`) >
-    `lake-manifest.json` (package-level) > imported-module signal. -/
-def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array ProjectModule) (crate : String)
-    (nixMode : Option NixMode := none) (classOverride : Option String := none)
-    : IO (Except String (Array Atom × Option String × Array (Name × Classification))) := do
+/-- Import the target project's built modules into a single `Environment`, with the
+    same LEAN_PATH / search-path setup and co-import preflight the analysis uses.
+    Shared by `runAnalysisViaLakeEnv` and the `check-axioms` command so both see the
+    exact same environment. -/
+def importProjectEnv (projectPath : System.FilePath) (modules : Array ProjectModule)
+    (nixMode : Option NixMode := none) : IO (Except String Environment) := do
   let absProjectPath ← IO.FS.realPath projectPath
 
   Lean.initSearchPath (← Lean.findSysroot)
@@ -261,8 +260,8 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Proje
 
   IO.println s!"Importing {imports.size} modules..."
 
-  let env ← try
-    importModules imports {} 0
+  try
+    return .ok (← importModules imports {} 0)
   catch e =>
     let msg := toString e
     if containsSubstring msg "already contains" then
@@ -300,12 +299,30 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Proje
       return .error s!"Failed to import modules: {msg}{hint}"
     return .error s!"Failed to import modules: {msg}"
 
+/-- Run analysis via lake env to get correct search paths.
+    Returns the atoms, the effective project class (`none` when no class is
+    detected), and the per-declaration classifications (empty when no class).
+    The class is resolved here — where both the environment and the project path
+    are available. Precedence: `classOverride` (from `--class`) >
+    `lake-manifest.json` (package-level) > imported-module signal. -/
+def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array ProjectModule) (crate : String)
+    (nixMode : Option NixMode := none) (classOverride : Option String := none)
+    : IO (Except String (Array Atom × Option String × Array (Name × Classification))) := do
+  let env ← match ← importProjectEnv projectPath modules nixMode with
+    | .error msg => return .error msg
+    | .ok env => pure env
+  let moduleNames := modules.map (·.name)
+
   IO.println "Extracting declarations..."
 
   -- Use the catalogue's game-head allowlist for codomain-shape (not the placeholder).
   let decls := getProjectDecls env moduleNames Catalogue.gameHeads
 
   IO.println s!"Found {decls.size} declarations"
+
+  -- Auto-detected `deriving`-generated instance clusters (names only). Flagged
+  -- below alongside projections; see the marking loop for why.
+  let derivedNames := derivedInstanceClusterNames decls
 
   -- Effective class: --class override > manifest (package-level) > imported modules.
   -- This is a disjunction (`orElse`): any positive signal classifies, so the order
@@ -326,6 +343,13 @@ def runAnalysisViaLakeEnv (projectPath : System.FilePath) (modules : Array Proje
   let mut atoms : Array Atom := #[]
   for decl in decls do
     let atom ← declInfoToAtom env projectPath moduleNames crate fileCache decl
+    -- Lean-generated code (deriving clusters + structure/class projections) is flagged
+    -- hidden + extraction-artifact so viewify and the web UI omit it from the presented
+    -- graph. It is kept in the atom set (not dropped), so `enrichTransitiveVerification`
+    -- still traverses it and contamination still flows through it — hiding is sound
+    -- precisely because the atom stays in the graph, unlike dropping.
+    let isGenerated := derivedNames.contains decl.name || decl.kind == .projection
+    let atom := if isGenerated then { atom with isHidden := true, isExtractionArtifact := true } else atom
     atoms := atoms.push atom
 
   return .ok (atoms, detectedClass, classifications)

--- a/ProbeLean/AxiomCheck.lean
+++ b/ProbeLean/AxiomCheck.lean
@@ -1,0 +1,89 @@
+/-
+  Kernel-level `sorry` detection via transitive axiom reachability.
+
+  `sorry` compiles to the `sorryAx` axiom, so a declaration rests on an unproven
+  placeholder iff `sorryAx` is reachable in its transitive closure (type + value of
+  every used constant, generated code included — recursors, instances, projections,
+  everything). This mirrors `Lean.collectAxioms` but is specialized to a single
+  reachability question and works from an `Environment` value directly (so callers
+  in plain `IO` don't need a `MonadEnv` monad), with a shared memo so a whole project
+  can be audited in roughly one pass over the dependency graph rather than
+  re-walking each declaration's closure.
+
+  It never prunes generated constants, so it is immune to whatever probe-lean's
+  extraction chooses to emit or drop — the independent ground truth for cross-checking
+  that no atom marked `transitively-verified` actually depends on a `sorry`.
+
+  The reachability core is generic over a `children` function, so its memo/cycle
+  handling is unit-testable with a fabricated graph (see `Tests`); the `Environment`
+  is only a thin `constChildren` adapter.
+-/
+import Lean
+
+namespace ProbeLean
+
+open Lean
+
+/-- The axiom `sorry` elaborates to. -/
+def sorryAxiomName : Name := `sorryAx
+
+/-- Memoized reachability: can `c` reach `target` following `children` edges?
+    Memo entries: `some b` decided, `none` on the DFS stack — a cyclic back-edge
+    contributes `false`, which is correct because a reachable node always has an
+    acyclic path to it. Pure, so it is unit-testable with a fabricated `children`. -/
+private partial def reachesAux (children : Name → Array Name) (target c : Name) :
+    StateM (Std.HashMap Name (Option Bool)) Bool := do
+  match (← get).get? c with
+  | some (some b) => return b
+  | some none     => return false
+  | none =>
+    if c == target then
+      modify (·.insert c (some true)); return true
+    modify (·.insert c none)
+    let mut res := false
+    for ch in children c do
+      unless res do
+        if ← reachesAux children target ch then res := true
+    modify (·.insert c (some res))
+    return res
+
+/-- Of `roots`, the subset that can reach `target`. One shared memo across all roots. -/
+def reachingNames (children : Name → Array Name) (target : Name) (roots : Array Name) :
+    Std.HashSet Name := Id.run do
+  let mut memo : Std.HashMap Name (Option Bool) := {}
+  let mut out : Std.HashSet Name := {}
+  for r in roots do
+    let (b, memo') := (reachesAux children target r).run memo
+    memo := memo'
+    if b then out := out.insert r
+  return out
+
+/-- Whether a single `root` can reach `target`. -/
+def reaches (children : Name → Array Name) (target root : Name) : Bool :=
+  (reachesAux children target root).run' {}
+
+/-- The constants directly used in `c`'s type and value (and constructors, for an
+    inductive) — the out-edges of the transitive closure. The match is exhaustive
+    over `ConstantInfo` on purpose: if Lean ever adds a constructor, this fails to
+    compile rather than silently under-reporting axioms. Mirrors `Lean.collectAxioms`. -/
+def constChildren (env : Environment) (c : Name) : Array Name :=
+  match env.find? c with
+  | some (.axiomInfo v)  => v.type.getUsedConstants
+  | some (.defnInfo v)   => v.type.getUsedConstants ++ v.value.getUsedConstants
+  | some (.thmInfo v)    => v.type.getUsedConstants ++ v.value.getUsedConstants
+  | some (.opaqueInfo v) => v.type.getUsedConstants ++ v.value.getUsedConstants
+  | some (.ctorInfo v)   => v.type.getUsedConstants
+  | some (.recInfo v)    => v.type.getUsedConstants
+  | some (.inductInfo v) => v.type.getUsedConstants ++ v.ctors.toArray
+  | some (.quotInfo _)   => #[]
+  | none                 => #[]
+
+/-- Of `roots`, the subset whose transitive closure reaches `sorryAx`. -/
+def sorryReachingNames (env : Environment) (roots : Array Name) : Std.HashSet Name :=
+  reachingNames (constChildren env) sorryAxiomName roots
+
+/-- Whether `name`'s transitive closure reaches `sorryAx`. -/
+def dependsOnSorryAxIn (env : Environment) (name : Name) : Bool :=
+  reaches (constChildren env) sorryAxiomName name
+
+end ProbeLean

--- a/ProbeLean/CheckAxioms.lean
+++ b/ProbeLean/CheckAxioms.lean
@@ -1,0 +1,44 @@
+/-
+  `check-axioms` command: a standalone `sorry` audit.
+
+  Builds and imports a target project (via the shared `prepareProject` +
+  `importProjectEnv` used by `extract`), then reports every declaration that
+  `extract` would emit as an atom whose *complete* transitive closure depends on
+  the `sorryAx` axiom — the kernel ground truth for "rests on a sorry", independent
+  of probe-lean's own dependency graph (see `AxiomCheck`).
+-/
+import ProbeLean.Extract
+import ProbeLean.Analysis
+import ProbeLean.AxiomCheck
+
+namespace ProbeLean
+
+open Lean
+
+/-- Build, import, and report declarations that transitively depend on `sorryAx`.
+    Returns a process exit code. -/
+def runCheckAxiomsInProject (projectPath : System.FilePath)
+    (libraries : Option (Array String) := none) (moduleFilter : Option String := none)
+    : IO UInt32 := do
+  let (filteredModules, nixMode, _) ←
+    match ← prepareProject projectPath libraries moduleFilter with
+    | .error code => return code
+    | .ok r => pure r
+
+  let env ← match ← importProjectEnv projectPath filteredModules nixMode with
+    | .error msg => IO.eprintln s!"Import failed: {msg}"; return 1
+    | .ok env => pure env
+
+  -- Audit exactly the declarations extract emits as atoms: `getProjectDecls` applies
+  -- the same isInternalName / project / ctor-rec / no-source-location filtering, so
+  -- this is a faithful cross-check of the emitted atom set.
+  let moduleNames := filteredModules.map (·.name)
+  let names := (getProjectDecls env moduleNames).map (·.name)
+  let flagged := sorryReachingNames env names        -- one shared-memo pass
+  let sorted := (names.filter flagged.contains).qsort (·.toString < ·.toString)
+  IO.println s!"Checked {names.size} declaration(s); {sorted.size} depend on `sorryAx`:"
+  for n in sorted do
+    IO.println s!"  {n}"
+  return 0
+
+end ProbeLean

--- a/ProbeLean/Extract.lean
+++ b/ProbeLean/Extract.lean
@@ -156,14 +156,18 @@ def duplicateAtomNames (atoms : Array Atom) : Array String := Id.run do
   let dups := counts.toList.filterMap fun (name, n) => if n > 1 then some name else none
   return dups.toArray.qsort (· < ·)
 
-/-- Run the combined extract pipeline: build → atomize → markAtomFlags → specs → sorry detection → merge → enrich → envelope → write -/
-def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
-  if !(← isLakeProject config.projectPath) then
-    IO.eprintln s!"Error: Not a Lake project: {config.projectPath}"
-    return 1
+/-- Build (honouring the cache) and discover/select the project's modules.
+    Shared by `runExtractInProject` and the `check-axioms` command so the audit path
+    and the extraction path can't drift on nix detection, build, or module selection.
+    Returns `(selected modules, nix mode, captured build output)`, or an exit code. -/
+def prepareProject (projectPath : System.FilePath) (libraries : Option (Array String))
+    (moduleFilter : Option String) : IO (Except UInt32 (Array ProjectModule × Option NixMode × String)) := do
+  if !(← isLakeProject projectPath) then
+    IO.eprintln s!"Error: Not a Lake project: {projectPath}"
+    return .error 1
 
   let nixMode ← do
-    match ← detectNixShell config.projectPath with
+    match ← detectNixShell projectPath with
     | some mode =>
       if ← isNixAvailable mode then
         IO.println s!"Nix environment detected ({mode}.nix), lake commands will run inside it."
@@ -177,58 +181,55 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
     | none => pure none
 
   let probeLeanVersion := Lean.versionString
-  let targetTC ← readToolchain config.projectPath
+  let targetTC ← readToolchain projectPath
   let targetVersionStr := match targetTC with
     | some tc => parseToolchainVersion tc
     | none    => "unknown (no lean-toolchain file)"
   IO.println s!"probe-lean built with Lean {probeLeanVersion}, target project uses {targetVersionStr}"
 
-  let libs ← match config.libraries with
+  let libs ← match libraries with
     | some ls => pure ls
-    | none => getLeanLibs config.projectPath
+    | none => getLeanLibs projectPath
 
-  let buildOutput ← if ← isCacheValid config.projectPath then
+  let buildOutput ← if ← isCacheValid projectPath then
     IO.println "Build cache is up-to-date, skipping lake build..."
-    match ← loadCache config.projectPath with
+    match ← loadCache projectPath with
     | some cached => pure cached
     | none => pure ""
   else do
-    ensureMathlibCache config.projectPath nixMode
+    ensureMathlibCache projectPath nixMode
     let buildArgs := if libs.isEmpty then #["build"] else #["build"] ++ libs
     if !libs.isEmpty then
       IO.println s!"Building libraries: {", ".intercalate libs.toList}"
-    IO.println s!"Building project at {config.projectPath}..."
-    let (buildStdout, buildStderr, buildExit) ← runLakeCmd buildArgs (some config.projectPath) nixMode
+    IO.println s!"Building project at {projectPath}..."
+    let (buildStdout, buildStderr, buildExit) ← runLakeCmd buildArgs (some projectPath) nixMode
     if buildExit != 0 then
       IO.eprintln s!"Lake build failed:\n{buildStderr}"
-      return 1
+      return .error 1
     let output := buildStdout ++ "\n" ++ buildStderr
-    saveCache config.projectPath output
+    saveCache projectPath output
     pure output
 
-  -- === Step 1: Atomize ===
-  IO.println "=== Step 1/3: Atomize ==="
-
   IO.println "Getting project modules..."
-  let sourceRoots ← getSourceRoots config.projectPath
-  let modules ← match ← getProjectModules config.projectPath nixMode sourceRoots with
+  let sourceRoots ← getSourceRoots projectPath
+  let modules ← match ← getProjectModules projectPath nixMode sourceRoots with
     | .error msg =>
       IO.eprintln msg
-      return 1
+      return .error 1
     | .ok mods => pure mods
 
   if modules.isEmpty then
     IO.eprintln "Error: No modules found in project"
-    return 1
+    return .error 1
 
-  let filteredModules := selectModules modules config.libraries config.moduleFilter
+  let filteredModules := selectModules modules libraries moduleFilter
 
   -- Warn about any explicit `--library` entry that matched no built module, so a
   -- partial filter (e.g. one good name + one typo, or a name that differs from
   -- the library's actual module root) isn't applied silently. Note `--library`
   -- matches by module-name prefix, so it cannot select a library whose `roots`
   -- differ from its name (use `--module <root>` for those).
-  if let some libs := config.libraries then
+  if let some libs := libraries then
     for lib in libs do
       if !(modules.any fun m => moduleInLibraries m.name #[lib]) then
         IO.eprintln s!"Warning: --library {lib} matched no built module (it is not a module-name root)."
@@ -241,9 +242,20 @@ def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
     IO.eprintln s!"  {modules.size} module(s) were built but none matched the requested filter."
     let roots := (modules.map fun m => (m.name.toString.splitOn ".").headD m.name.toString).toList.eraseDups
     IO.eprintln s!"  Available top-level module roots: {", ".intercalate roots}"
-    return 1
+    return .error 1
 
   IO.println s!"Analyzing {filteredModules.size} modules..."
+  return .ok (filteredModules, nixMode, buildOutput)
+
+/-- Run the combined extract pipeline: build → atomize → markAtomFlags → specs → sorry detection → merge → enrich → envelope → write -/
+def runExtractInProject (config : ExtractConfig) : IO UInt32 := do
+  let (filteredModules, nixMode, buildOutput) ←
+    match ← prepareProject config.projectPath config.libraries config.moduleFilter with
+    | .error code => return code
+    | .ok r => pure r
+
+  -- === Step 1: Atomize ===
+  IO.println "=== Step 1/3: Atomize ==="
 
   let userConfig ← loadUserConfig config.projectPath
   let crate := loadRelevantCrate userConfig

--- a/ProbeLean/Main.lean
+++ b/ProbeLean/Main.lean
@@ -1,9 +1,11 @@
 /-
   CLI entry point for probe-lean.
-  Two commands: extract (combined atomize+specify+sorry detection) and viewify (molecules output).
+  Commands: extract (combined atomize+specify+sorry detection), viewify (molecules
+  output), and check-axioms (transitive sorryAx audit).
 -/
 import Cli
 import ProbeLean.Extract
+import ProbeLean.CheckAxioms
 import ProbeLean.View
 import ProbeLean.Version
 
@@ -66,6 +68,27 @@ def extractCmd : Cmd := `[Cli|
     projectPath : String; "Path to the Lean 4 project to analyze"
 ]
 
+/-- Run the check-axioms command -/
+def runCheckAxioms (parsed : Parsed) : IO UInt32 := do
+  let projectPath := normalizePath (parsed.positionalArg! "projectPath" |>.as! String)
+  let moduleFilter := parsed.flag? "module" |>.map (·.as! String)
+  let libraries := parsed.flag? "library" |>.map fun f =>
+    (f.as! String).splitOn "," |>.map (fun s => s.trimAscii.toString) |>.toArray
+  runCheckAxiomsInProject projectPath libraries moduleFilter
+
+/-- The check-axioms subcommand -/
+def checkAxiomsCmd : Cmd := `[Cli|
+  "check-axioms" VIA runCheckAxioms; ["0.0.0"]
+  "Audit a Lean 4 project: report declarations whose transitive closure depends on `sorryAx`"
+
+  FLAGS:
+    m, module : String; "Filter to specific module prefix"
+    l, library : String; "Comma-separated library names to build AND restrict analysis to"
+
+  ARGS:
+    projectPath : String; "Path to the Lean 4 project to audit"
+]
+
 /-- Run the viewify command -/
 def runView (parsed : Parsed) : IO UInt32 := do
   let projectPath := normalizePath (parsed.positionalArg! "projectPath" |>.as! String)
@@ -107,7 +130,8 @@ def probeleanCmd : Cmd :=
 
     SUBCOMMANDS:
       extractCmd;
-      viewCmd
+      viewCmd;
+      checkAxiomsCmd
   ]).withVersion ProbeLean.version
 
 /-- Entry point -/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For Mathlib cache setup, Nix/FFI projects, and real-project walkthroughs, see **
 | Command | Description |
 |---------|-------------|
 | `extract` | Analyze a Lean 4 project: extract atoms, detect sorries, compute specs |
+| `check-axioms` | Audit a project: report declarations transitively depending on `sorryAx` |
 
 ### `extract`
 
@@ -145,6 +146,22 @@ probe-lean extract <PROJECT_PATH> [OPTIONS]
 | `--from-file <FILE>` | Use existing build output for sorry detection |
 | `--skip-enrich` | Skip transitive verification enrichment (no `"transitively-verified"` status) |
 | `--class <NAME>` | Override the detected project class (e.g. `security-protocol`) |
+
+### `check-axioms`
+
+```bash
+probe-lean check-axioms <PROJECT_PATH> [-m <PREFIX>] [-l <LIBS>]
+```
+
+Builds and imports the project, then lists every declaration whose *complete*
+transitive closure reaches the `sorryAx` axiom — the kernel ground truth for
+"rests on a `sorry`", independent of the extract dependency graph. Use it to
+cross-check `extract` output: no atom marked `"transitively-verified"` should
+appear here (if one does, the emitted graph lost a contamination path).
+
+> Note: the audit walks each declaration's axiom closure independently
+> (`O(declarations × closure size)`), so on very large projects (Mathlib-scale
+> closures) it can be slow. Use `-m`/`-l` to narrow the scope.
 
 ### Security-protocol classification
 
@@ -201,7 +218,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 
 1. **Build** -- reads `defaultTargets` from `lakefile.toml` (falling back to all `[[lean_lib]]` entries) and runs `lake build <lib1> ...` to produce `.olean` files (automatically skipped when build cache is up-to-date; overridable via `--library`)
 2. **Atomize** -- walks the Lean environment, extracts declarations with type and term dependencies
-3. **Filter** -- applies config-based flags (`is-hidden`, `is-extraction-artifact`, `is-ignored`, `is-relevant`)
+3. **Filter** -- applies config-based flags (`is-hidden`, `is-extraction-artifact`, `is-ignored`, `is-relevant`), and auto-flags Lean-generated code — `deriving`-generated instance clusters and structure/class projections — as `is-hidden` + `is-extraction-artifact` so `viewify` and the web UI omit it. Such atoms are **kept in the dependency graph** (so transitive-verification stays sound), only hidden from the presented view
 4. **Specs** -- computes reverse theorem edges (`specs`, `primary-spec`) for each atom using a multi-signal precedence chain:
     1. `@[primary_spec]` attribute (always wins; requires `import ProbeLean.Attrs` in the target project)
     2. Known verification-framework attributes (`@[progress]`, `@[pspec]`, `@[step]`) — if exactly one spec theorem carries one of these, it becomes primary spec; ambiguous when multiple match

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -37,6 +37,83 @@ def testConstants (result : TestResult) : IO TestResult := do
   result ← test "schemaView" (Constants.schemaView == "probe-lean/viewify") result
   return result
 
+def testCoversRange (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing coversRange..."
+  let r (s e : Nat) : CodeTextInfo := { linesStart := s, linesEnd := e }
+  -- strict interior
+  result ← test "interior" (coversRange (r 10 20) (r 12 15)) result
+  -- shared boundary (deriving collapsed onto type's last line) still covered
+  result ← test "shared end boundary" (coversRange (r 63 69) (r 69 69)) result
+  result ← test "shared start boundary" (coversRange (r 63 69) (r 63 65)) result
+  -- identical range is excluded
+  result ← test "equal range excluded" (!coversRange (r 63 69) (r 63 69)) result
+  -- outside / partial overlap not covered (the DecidableEq-after-type case)
+  result ← test "after type" (!coversRange (r 63 69) (r 71 75)) result
+  result ← test "partial overlap" (!coversRange (r 63 69) (r 68 72)) result
+  result ← test "disjoint" (!coversRange (r 10 20) (r 30 40)) result
+  return result
+
+def testAxiomReachability (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing sorry-axiom reachability (reaches / reachingNames)..."
+  -- Fabricated dependency graph exercising the risky traversal logic: direct hit,
+  -- transitive hit, no hit, self-cycle, a cycle that still reaches the target, a
+  -- pure cycle, and a diamond (shared subtree must be memoized, not miscounted).
+  let children : Lean.Name → Array Lean.Name := fun n => match n with
+    | `a => #[`b]
+    | `b => #[`SORRY]
+    | `c => #[`d]
+    | `e => #[`e]              -- self-cycle, never reaches target
+    | `f => #[`g, `SORRY]
+    | `g => #[`f]              -- cycle, but f reaches target
+    | `h => #[`i]
+    | `i => #[`h]              -- pure cycle, no target
+    | `x => #[`y, `z]          -- diamond
+    | `y => #[`SORRY]
+    | `z => #[`w]
+    | _  => #[]
+  let R := reaches children `SORRY
+  result ← test "transitive hit" (R `a) result
+  result ← test "no hit" (!R `c) result
+  result ← test "self-cycle, no hit" (!R `e) result
+  result ← test "cycle reaching target (f)" (R `f) result
+  result ← test "cycle reaching target (g via f)" (R `g) result
+  result ← test "pure cycle, no hit" (!R `h) result
+  result ← test "diamond hit via y" (R `x) result
+  result ← test "target itself" (R `SORRY) result
+  let flagged := reachingNames children `SORRY #[`a, `c, `e, `x, `h]
+  result ← test "reachingNames selects reachers only"
+    (flagged.contains `a && flagged.contains `x &&
+     !flagged.contains `c && !flagged.contains `e && !flagged.contains `h) result
+  return result
+
+def testDerivedInstanceClusterNames (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing derivedInstanceClusterNames..."
+  let mk (name : Lean.Name) (kind : DeclKind) (s e : Nat) : DeclInfo :=
+    { name, displayName := getDisplayName name, moduleName := `Test, kind,
+      dependencies := #[], typeDependencies := #[], termDependencies := #[],
+      sourceInfo := some { linesStart := s, linesEnd := e } }
+  let decls : Array DeclInfo := #[
+    mk `Foo .structure 10 15,                 -- the type
+    mk `instReprFoo .instance 15 15,          -- derived instance (inside) → selected
+    mk `instReprFoo.repr .def 15 15,          -- backing member (prefix is derived) → selected
+    mk `Foo.field .projection 12 12,          -- projection: handled separately, NOT here
+    mk `Foo.helper .def 11 11,                -- plain member inside type → not selected
+    mk `instBar .instance 20 22 ]             -- hand-written top-level instance → not selected
+  let got := derivedInstanceClusterNames decls
+  result ← test "derived instance selected" (got.contains `instReprFoo) result
+  result ← test "backing member selected" (got.contains `instReprFoo.repr) result
+  result ← test "projection not selected" (!got.contains `Foo.field) result
+  result ← test "plain inside-type member not selected" (!got.contains `Foo.helper) result
+  result ← test "hand-written top-level instance not selected" (!got.contains `instBar) result
+  result ← test "type itself not selected" (!got.contains `Foo) result
+  return result
+
 def testAnalysisHelpers (result : TestResult) : IO TestResult := do
   let mut result := result
   IO.println ""
@@ -287,16 +364,31 @@ def testAtomizeHelpers (result : TestResult) : IO TestResult := do
     codeText := none
     kind := .def
   }
+  -- Pre-flagged atom (e.g. an auto-detected generated atom): markAtomFlags must
+  -- OR, not overwrite — the config pass adds to automatic detection.
+  let preFlagged : Atom := {
+    name := "probe:Test.instReprFoo"
+    displayName := "instReprFoo"
+    dependencies := #[]
+    codeModule := "Test"
+    codePath := "Test.lean"
+    codeText := none
+    kind := .instance
+    isHidden := true
+    isExtractionArtifact := true
+  }
   let hiddenList : Array String := #["Test.foo"]
   let artifactSuffixes : Array String := #["_body", "_loop"]
   let ignoredList : Array String := #["Test.ignored_func"]
-  let markedAtoms := markAtomFlags #[testAtomForHidden, testAtomForHidden2, testAtomArtifact, testAtomIgnored] hiddenList artifactSuffixes ignoredList
+  let markedAtoms := markAtomFlags #[testAtomForHidden, testAtomForHidden2, testAtomArtifact, testAtomIgnored, preFlagged] hiddenList artifactSuffixes ignoredList
   result ← test "marked atom is hidden" markedAtoms[0]!.isHidden result
   result ← test "unmarked atom is not hidden" (!markedAtoms[1]!.isHidden) result
   result ← test "artifact atom is extraction artifact" markedAtoms[2]!.isExtractionArtifact result
   result ← test "non-artifact atom is not extraction artifact" (!markedAtoms[0]!.isExtractionArtifact) result
   result ← test "ignored atom is ignored" markedAtoms[3]!.isIgnored result
   result ← test "non-ignored atom is not ignored" (!markedAtoms[0]!.isIgnored) result
+  result ← test "pre-set hidden survives (OR, not overwrite)" markedAtoms[4]!.isHidden result
+  result ← test "pre-set artifact survives (OR, not overwrite)" markedAtoms[4]!.isExtractionArtifact result
   return result
 
 def testComputeSpecs (result : TestResult) : IO TestResult := do
@@ -3423,6 +3515,30 @@ def testTransitiveVerificationJson (result : TestResult) : IO TestResult := do
   result ← test "UnifiedAtom transitively-verified round-trips" tvRtOk result
   return result
 
+/-- Regression guard for the mark-not-drop fix: a theorem T that reaches an
+    unverified U *only through* a derived instance I must NOT be reported as
+    `transitively-verified`. Dropping I (removing it from the atom set while T still
+    lists it as a dep) is exactly what would falsely upgrade T — so this pins why
+    generated atoms are hidden, not dropped. -/
+def testDropRegression (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing mark-not-drop contamination (T → I → U)..."
+  let u := mkUnified "U" #[] (some .unverified)
+  let i := mkUnified "I" #["U"] (some .verified)     -- derived instance, locally verified
+  let t := mkUnified "T" #["I"] (some .verified)
+  -- I present: contamination U → I → T, so T is held at `verified` (sound).
+  let (kept, _, _, _) := enrichTransitiveVerification #[t, i, u]
+  result ← test "I kept → T stays verified (not upgraded)"
+    (getVS (findUA kept "T").get! == some .verified) result
+  result ← test "I kept → I stays verified (contaminated)"
+    (getVS (findUA kept "I").get! == some .verified) result
+  -- I dropped (T still lists it): the U → I → T path is severed → T wrongly upgraded.
+  let (dropped, _, _, _) := enrichTransitiveVerification #[t, u]
+  result ← test "I dropped → T wrongly transitively-verified (the avoided bug)"
+    (getVS (findUA dropped "T").get! == some .transitivelyVerified) result
+  return result
+
 def main : IO UInt32 := do
   let mut result : TestResult := { passed := 0, failed := 0 }
   result ← testConstants result
@@ -3496,6 +3612,10 @@ def main : IO UInt32 := do
   result ← testTransitiveVerificationProperties result
   result ← testPartitionMissingDeps result
   result ← testTransitiveVerificationJson result
+  result ← testCoversRange result
+  result ← testAxiomReachability result
+  result ← testDerivedInstanceClusterNames result
+  result ← testDropRegression result
 
   IO.println ""
   IO.println s!"Results: {result.passed} passed, {result.failed} failed"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -85,6 +85,30 @@ For VCVio-based cryptographic projects, `extract` additionally classifies declar
 `classification` object (see [SCHEMA.md](SCHEMA.md#security-protocol-classification)). Schemes not
 named `*Scheme`/`*Alg` must carry `@[scheme_def]` (import `ProbeLean.Attrs`) to be detected.
 
+`extract` also auto-flags Lean-generated code — `deriving`-generated instance clusters and
+structure/class projections — as `is-hidden` + `is-extraction-artifact`, so `viewify` and the web UI
+omit it. These atoms stay in the dependency graph, so transitive-verification remains sound.
+
+### `check-axioms`
+
+Audit a Lean 4 project: report every declaration (of those `extract` would emit as an atom) whose
+*complete* transitive closure reaches the `sorryAx` axiom.
+
+```
+probe-lean check-axioms <PROJECT_PATH> [OPTIONS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--module <PREFIX>` | `-m` | Filter to specific module prefix |
+| `--library <LIBS>` | `-l` | Comma-separated library names to build **and** restrict analysis to |
+
+This is the kernel ground truth for "rests on a `sorry`", walked via `Lean`'s constant closure
+(generated code included) and therefore independent of probe-lean's own dependency graph. Use it to
+cross-check `extract`: no atom marked `"transitively-verified"` should appear in this list. The audit
+walks each declaration's closure (`O(declarations × closure size)`), so on Mathlib-scale projects use
+`-m`/`-l` to narrow scope.
+
 ---
 
 ## Walkthrough: Analyzing Real Projects


### PR DESCRIPTION
Closes #71.

## What

- **Hide, don't drop, Lean-generated code.** `deriving`-generated instance clusters
  and structure/class projections are flagged `is-hidden` + `is-extraction-artifact`
  in atomization. They stay in the dependency graph — so `enrichTransitiveVerification`
  still propagates contamination through them and cannot falsely upgrade a dependent
  to `transitively-verified` — while `viewify`/the web UI omit them.
  `markAtomFlags` now ORs these flags so config adds to auto-detection.
- **New `probe-lean check-axioms <project>`** — reports declarations (of those
  `extract` emits as atoms) whose transitive closure reaches `sorryAx`, the kernel
  ground truth, independent of the extract graph. Use it to cross-check that no
  `transitively-verified` atom rests on a `sorry`. Shares `prepareProject` /
  `importProjectEnv` with `extract` so the two paths can't drift.

## Why

Dropping a *referenced* generated node was unsound: missing deps are treated as
trusted and never contaminate, so a theorem depending on a dropped instance that
transitively rests on a `sorry` could be marked `transitively-verified`.

## Tests

`Tests/Main.lean`: contamination regression (drop → false `transitively-verified`),
the cluster detector, the reachability traversal (cycles/diamonds), and
`markAtomFlags` flag preservation. Full suite: 619 passing.

## Notes

- `viewify` output no longer includes projection / derived-instance nodes (behavior
  change, in CHANGELOG).
- Version bump deferred to release, consistent with the existing unreleased breaking
  schema-3.0 change (changes accumulate under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)