### PR TITLE
Revert extract envelope schema-version to 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,15 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   catalogue + classifier), the `Classification`/`SecurityProtocolCategory`/`ClassVia`
   types, and project-class/manifest detection. These fields were never part of a
   released schema and had no consumers, so their removal is not a schema break (the
-  schema-version stays 4.0). probe-vcvio consumes probe-lean's envelope and
+  schema-version stays 3.0). probe-vcvio consumes probe-lean's envelope and
   reproduces the same `classification` shape from the emitted `codomain-*` facts.
 
 ### Changed
 
-- **Split `is-extraction-artifact` into `is-lean-generated` + `is-aeneas-generated`**
-  (breaking). The old field conflated two distinct origins: Lean-generated code
+- **Split `is-extraction-artifact` into `is-lean-generated` + `is-aeneas-generated`.**
+  The old field conflated two distinct origins: Lean-generated code
   (derived instances, projections) and Aeneas-generated scaffolding (`_body`, `_loop`
-  suffixes). Each now has its own field with accurate naming.
+  suffixes). Each now has its own field with accurate naming. No interchange break:
+  no other probe consumes these fields (probe-aeneas computes its own
+  `is-extraction-artifact` from a name heuristic), so this is an additive payload
+  change, not an envelope-schema change.
 - **Conditional `is-hidden` for lean-generated atoms.** After transitive enrichment,
   `is-hidden` is cleared on *contaminated* lean-generated atoms — those that are
   locally verified but not transitively verified, or are themselves unverified/failed —
@@ -48,8 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   downstream atoms aren't dark green (fully verified). Clean (`transitively-verified`)
   and `trusted` lean-generated atoms stay hidden. `viewify` molecules omit all generated
   atoms regardless of `is-hidden`.
-- Bumped schema-version to 4.0 (breaking): `is-extraction-artifact` replaced by
-  `is-lean-generated` + `is-aeneas-generated`, `is-hidden` semantics updated.
+- Schema-version stays 3.0: the envelope structure is unchanged. The
+  `is-extraction-artifact` → `is-lean-generated`/`is-aeneas-generated` rename and the
+  updated `is-hidden` semantics affect only probe-lean's own payload, which is absorbed
+  by consumers' passthrough `extensions`, so no shared version bump is warranted.
 - The config key `extraction-artifact-suffixes` in `.verilib/probes/config.json` now
   feeds the `is-aeneas-generated` field (backward compatible, no config migration).
 - `extract` auto-flags Lean-generated code — `deriving`-generated instance clusters and

--- a/ProbeLean/Loader.lean
+++ b/ProbeLean/Loader.lean
@@ -1,6 +1,6 @@
 /-
   Shared loading functions for probe-lean output files.
-  Handles both bare-dict (Schema 1.x) and enveloped (Schema 4.0) formats.
+  Handles both bare-dict (Schema 1.x) and enveloped (Schema 3.0) formats.
 -/
 import Lean
 import ProbeLean.Types
@@ -9,7 +9,7 @@ namespace ProbeLean
 
 open Lean
 
-/-- Extract the atom data from JSON, unwrapping the Schema 4.0 envelope if present. -/
+/-- Extract the atom data from JSON, unwrapping the Schema 3.0 envelope if present. -/
 def unwrapEnvelope (json : Json) : Json :=
   match json.getObjVal? "schema", json.getObjVal? "data" with
   | .ok (.str _), .ok data => data

--- a/ProbeLean/Metadata.lean
+++ b/ProbeLean/Metadata.lean
@@ -1,5 +1,5 @@
 /-
-  Schema 4.0 metadata gathering and output path construction.
+  Schema 3.0 metadata gathering and output path construction.
   Reads git info and lakefile to populate envelope fields.
   Callers construct typed `Envelope α` directly rather than using generic wrappers.
 -/

--- a/ProbeLean/Types.lean
+++ b/ProbeLean/Types.lean
@@ -1,6 +1,6 @@
 /-
   Types for probe-lean output.
-  Defines atoms, specs, proofs, stubs, and Schema 4.0 envelope types
+  Defines atoms, specs, proofs, stubs, and Schema 3.0 envelope types
   with JSON serialization matching the probe interchange spec.
 -/
 import Lean.Data.Json
@@ -20,16 +20,16 @@ namespace Constants
   def mapsDir : String := "maps"
   def toolName : String := "probe-lean"
   def toolVersion : String := ProbeLean.version
-  def schemaVersion : String := "4.0"
+  def schemaVersion : String := "3.0"
   def schemaExtract : String := "probe-lean/extract"
   def schemaView : String := "probe-lean/viewify"
 end Constants
 
 -- ============================================================
--- Schema 4.0 envelope types
+-- Schema 3.0 envelope types
 -- ============================================================
 
-/-- Tool metadata for the Schema 4.0 envelope -/
+/-- Tool metadata for the Schema 3.0 envelope -/
 structure ToolInfo where
   name : String := Constants.toolName
   version : String := Constants.toolVersion
@@ -50,7 +50,7 @@ instance : Lean.FromJson ToolInfo where
     let command ← json.getObjValAs? String "command"
     return { name, version, command }
 
-/-- Source metadata for the Schema 4.0 envelope.
+/-- Source metadata for the Schema 3.0 envelope.
     `repo` and `commit` are non-optional String (empty when unavailable)
     to conform to the probe repo JSON Schema which declares them required. -/
 structure SourceInfo where
@@ -80,7 +80,7 @@ instance : Lean.FromJson SourceInfo where
     let packageVersion ← json.getObjValAs? String "package-version"
     return { repo, commit, language, package, packageVersion }
 
-/-- Typed envelope wrapper for all Schema 4.0 outputs -/
+/-- Typed envelope wrapper for all Schema 3.0 outputs -/
 structure Envelope (α : Type) where
   schema : String
   schemaVersion : String := Constants.schemaVersion

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Analyze Lean 4 projects: extract dependency graphs with verification status and spec relationships.
 
-`probe-lean` walks the Lean environment of a built project and produces structured JSON describing every declaration, its dependencies (type and term), source locations, sorry-based verification status, and spec relationships. Output follows the Schema 4.0 envelope format; see [docs/SCHEMA.md](docs/SCHEMA.md) for the full specification.
+`probe-lean` walks the Lean environment of a built project and produces structured JSON describing every declaration, its dependencies (type and term), source locations, sorry-based verification status, and spec relationships. Output follows the Schema 3.0 envelope format; see [docs/SCHEMA.md](docs/SCHEMA.md) for the full specification.
 
 ## Prerequisites
 
@@ -183,7 +183,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "4.0",
+  "schema-version": "3.0",
   "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",
@@ -230,7 +230,7 @@ Running `probe-lean extract` produces a JSON envelope. Each entry in `data` desc
     4. Sole spec — if a definition has exactly one spec theorem, it is used as primary spec
 5. **Verify** -- parses sorry warnings from build output to determine verification status (shallow: checks only the declaration's own body, not its dependencies); axioms, declarations tagged `@[externally_verified]`, and non-theorem `*External.lean` declarations are marked `"trusted"` with a `trusted-reason` (`"axiom"`, `"externally_verified"`, or `"external"`) for trust-base classification; theorems in `*External.lean` without `@[externally_verified]` carry real proofs and receive their normal verification status; declarations without source location (kernel-synthesized) are filtered from output (skippable via `--skip-verify`)
 6. **Enrich** -- upgrades `"verified"` atoms to `"transitively-verified"` when all transitive dependencies are verified or trusted, using reverse-BFS contamination (matching `probe-verus`/`probe-aeneas`; skippable via `--skip-enrich`)
-7. **Schema 4.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
+7. **Schema 3.0 output** -- wraps atoms in a metadata envelope with git commit, package info, and timestamps
 
 ## How probe-lean decides what to analyze
 

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -32,7 +32,7 @@ def testConstants (result : TestResult) : IO TestResult := do
   result ← test "mapsDir" (Constants.mapsDir == "maps") result
   result ← test "toolName" (Constants.toolName == "probe-lean") result
   result ← test "toolVersion" (Constants.toolVersion == ProbeLean.version) result
-  result ← test "schemaVersion" (Constants.schemaVersion == "4.0") result
+  result ← test "schemaVersion" (Constants.schemaVersion == "3.0") result
   result ← test "schemaExtract" (Constants.schemaExtract == "probe-lean/extract") result
   result ← test "schemaView" (Constants.schemaView == "probe-lean/viewify") result
   return result
@@ -277,7 +277,7 @@ def testTypeJsonSerialization (result : TestResult) : IO TestResult := do
   let hasSchema := match envJson.getObjValAs? String "schema" with
     | .ok "probe-lean/extract" => true | _ => false
   let hasSchemaVer := match envJson.getObjValAs? String "schema-version" with
-    | .ok "4.0" => true | _ => false
+    | .ok "3.0" => true | _ => false
   let hasTool := match envJson.getObjVal? "tool" with
     | .ok _ => true | _ => false
   let hasSource := match envJson.getObjVal? "source" with
@@ -1108,7 +1108,7 @@ def testEnvelopeAwareLoading (result : TestResult) : IO TestResult := do
   ]
   let enveloped := Lean.Json.mkObj [
     ("schema", Lean.toJson "probe-lean/extract"),
-    ("schema-version", Lean.toJson "4.0"),
+    ("schema-version", Lean.toJson "3.0"),
     ("data", bareDict)
   ]
   let bareStr := Lean.Json.pretty bareDict
@@ -1164,7 +1164,7 @@ def testEnvelopeAwareLoading (result : TestResult) : IO TestResult := do
   IO.println "Testing unwrapEnvelope accepts any schema prefix..."
   let foreignEnvelope := Lean.Json.mkObj [
     ("schema", Lean.toJson "probe-verus/atoms"),
-    ("schema-version", Lean.toJson "4.0"),
+    ("schema-version", Lean.toJson "3.0"),
     ("data", bareDict)
   ]
   let foreignUnwrapped := match Lean.Json.parse (Lean.Json.pretty foreignEnvelope) with
@@ -1718,8 +1718,8 @@ def testExampleJsonEnvelopeStructure (result : TestResult) : IO TestResult := do
       | .ok "probe-lean/extract" => true | _ => false
     result ← test "envelope schema is probe-lean/extract" schemaOk result
     let versionOk := match json.getObjValAs? String "schema-version" with
-      | .ok "4.0" => true | _ => false
-    result ← test "envelope schema-version is 4.0" versionOk result
+      | .ok "3.0" => true | _ => false
+    result ← test "envelope schema-version is 3.0" versionOk result
     let hasTimestamp := match json.getObjValAs? String "timestamp" with
       | .ok s => !s.isEmpty | _ => false
     result ← test "envelope has non-empty timestamp" hasTimestamp result

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,21 +1,21 @@
-# Schema 4.0: Lean Instantiation
+# Schema 3.0: Lean Instantiation
 
-Version: 4.0
+Version: 3.0
 Date: 2026-07-31
 Parent document: [probes/docs/envelope-rationale.md](https://github.com/Beneficial-AI-Foundation/probe/blob/main/docs/envelope-rationale.md)
 
-This document defines the Lean-specific details for Schema 4.0 as produced by `probe-lean`.
+This document defines the Lean-specific details for Schema 3.0 as produced by `probe-lean`.
 It instantiates the generic envelope and atom schema from the parent document with Lean
 declaration kinds, code-name URIs, versioning, and field mappings.
 
 ## Envelope Example
 
-A complete probe-lean extract output with the Schema 4.0 envelope:
+A complete probe-lean extract output with the Schema 3.0 envelope:
 
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "4.0",
+  "schema-version": "3.0",
   "tool": {
     "name": "probe-lean",
     "version": "0.4.5",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -291,12 +291,12 @@ probe-lean extract ./my-project -m MyProject.Core
 
 For the complete JSON schema specification, see [SCHEMA.md](SCHEMA.md).
 
-The `extract` command produces a JSON file wrapped in a Schema 4.0 metadata envelope:
+The `extract` command produces a JSON file wrapped in a Schema 3.0 metadata envelope:
 
 ```json
 {
   "schema": "probe-lean/extract",
-  "schema-version": "4.0",
+  "schema-version": "3.0",
   "tool": { "name": "probe-lean", "version": "0.8.0", "command": "extract" },
   "source": {
     "repo": "https://github.com/org/project",

--- a/examples/lean_Curve25519Dalek_0.1.0.json
+++ b/examples/lean_Curve25519Dalek_0.1.0.json
@@ -12,7 +12,7 @@
   "language": "lean",
   "commit": "df8fb499e1cee086c23de96cba57622326863c8e"
  },
- "schema-version": "4.0",
+ "schema-version": "3.0",
  "schema": "probe-lean/extract",
  "data": {
   "probe:Aeneas.Std.U64.shiftRight_51": {


### PR DESCRIPTION
Closes #81.

## Why

The `extract` envelope was bumped to `schema-version` 4.0 for a payload-only change (`is-extraction-artifact` split into `is-lean-generated`/`is-aeneas-generated`, updated `is-hidden` semantics). That change touches probe-lean's own atom fields, not the shared envelope structure.

The shared `probe` crate gates every envelope with `schema-version.starts_with("3.")`, so 4.0 output is rejected downstream — `probe-aeneas extract` fails at load time.

The bump was unwarranted: no other probe consumes the renamed fields (probe-aeneas computes its own `is-extraction-artifact` from a name heuristic; probe-vcvio references none), and consumers absorb unknown fields via passthrough `extensions`. The rename is an additive payload change, not an envelope-schema change.

## What

- Revert emitted `schema-version` to 3.0 (`ProbeLean/Types.lean`), keeping the field rename.
- Sweep tests, docs, README, example fixture, and doc comments for consistency.
- CHANGELOG: drop the "bumped to 4.0 (breaking)" line; reclassify the field split as an additive payload change.

## Note

Based on `feat/remove-vcvio-classification` (#75), which introduced the 4.0 bump. Not build-tested locally due to a stale `.olean` cache / toolchain mismatch; test assertions were updated to match the reverted constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)