### PR TITLE
fix(extract): derive module names component-wise so guillemet modules import and keep source locations (0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-17
+
+### Fixed
+
+- **`extract` no longer aborts on modules whose file name needs guillemets** (#94).
+  Module names were derived from olean paths with `String.toName`, which mangles
+  any non-identifier segment: segments with hyphens or spaces collapse the whole
+  name to `.anonymous`, and digit-only segments become numeric components — both
+  invalid as module names. `importModules` then rejected the import list with
+  `import failed, trying to import module with anonymous name`. This crashed the
+  flagless invocation (the one VeriLib's atomizer uses) on e.g. teorth/analysis,
+  whose `Analysis.Misc.«Real-EReal-ENNReal»` is a legal Lake module. With
+  `--library` the anonymous name was silently dropped from the import list instead,
+  so such a module's atoms survived only if another module imported it. Names are
+  now built one atomic component per path segment (`pathToModuleName`) — the same
+  construction Lean core's `moduleNameOfFileName` uses — which represents guillemet
+  components exactly in both modes.
+- **Declarations in guillemet-named modules regain source locations and
+  verification status** (#94). `getModuleSourcePath` rebuilt the source path by
+  string-replacing dots in `Name.toString`, producing guillemet-quoted paths
+  (`Misc/«Real-EReal-ENNReal».lean`) that never exist on disk. Every declaration
+  in such a module therefore lost its `code-path`/`code-text`, its source-level
+  attributes, and — because sorry matching needs the location — was conservatively
+  reported `unverified` even when fully proved (17 such atoms on teorth/analysis).
+  The path is now rebuilt component-wise (`moduleNameToRelPath`, the exact inverse
+  of `pathToModuleName`).
+
 ## [0.12.0] - 2026-08-07
 
 ### Fixed

--- a/ProbeLean/Analysis.lean
+++ b/ProbeLean/Analysis.lean
@@ -4,6 +4,7 @@
 import Lean
 import ProbeLean.Types
 import ProbeLean.Attrs
+import ProbeLean.Environment
 
 namespace ProbeLean
 
@@ -166,10 +167,15 @@ def getDependencies (info : ConstantInfo) : DependencyInfo :=
   let sortByName (arr : Array Name) := arr.qsort fun a b => a.toString < b.toString
   { typeDeps := sortByName typeConsts, termDeps := sortByName valueConsts, all := sortByName all }
 
-/-- Get source file path for a module (relative to project root) -/
+/-- Get source file path for a module (relative to project root).
+    Converts component-wise via `moduleNameToRelPath`: rendering the name with
+    `Name.toString` would wrap non-identifier components in guillemets
+    (`Misc/«Real-EReal-ENNReal».lean`), a path that never exists on disk, so
+    such modules would lose their source location (and with it code text,
+    source attributes, and sorry matching). -/
 def getModuleSourcePath (_env : Environment) (projectPath : System.FilePath) (modName : Name) : IO (Option String) := do
-  -- Convert module name to relative file path
-  let relPath := modName.toString.replace "." "/" ++ ".lean"
+  let some rel := moduleNameToRelPath modName | return none
+  let relPath := rel ++ ".lean"
   let fullPath := projectPath / relPath
   if ← fullPath.pathExists then
     return some relPath

--- a/ProbeLean/Environment.lean
+++ b/ProbeLean/Environment.lean
@@ -133,6 +133,32 @@ def loadCache (projectPath : System.FilePath) : IO (Option String) := do
   else
     return none
 
+/-- Convert an olean's slash-separated relative path (`.olean` suffix already
+    stripped) to its module name, one atomic component per path segment — the
+    same construction Lean core uses (`Lean.moduleNameOfFileName`).
+    Built with `Name.mkStr` rather than `String.toName` because path segments
+    are not necessarily plain identifiers: a file like
+    `Misc/Real-EReal-ENNReal.lean` is a legal Lake module whose name is
+    written `Misc.«Real-EReal-ENNReal»`, and `String.toName` mangles such
+    segments (non-identifier segments collapse the whole name to `.anonymous`,
+    which `importModules` rejects outright; digit-only segments become numeric
+    components, which are invalid in module names). -/
+def pathToModuleName (relPath : String) : Lean.Name :=
+  (relPath.splitOn "/").foldl .mkStr .anonymous
+
+/-- Convert a module name back to the slash-separated relative path of its
+    backing source file (extension not included) — the inverse of
+    `pathToModuleName`. Reads each atomic component's string directly rather
+    than going through `Name.toString`, whose guillemet quoting
+    (`Misc.«Real-EReal-ENNReal»`) never appears in file names. Module names
+    have no numeric components (Lean's own module-path resolution rejects
+    them), so a `.num` component yields `none`. -/
+def moduleNameToRelPath : Lean.Name → Option String
+  | .anonymous => none
+  | .str .anonymous s => some s
+  | .str p s => (moduleNameToRelPath p).map (· ++ "/" ++ s)
+  | .num _ _ => none
+
 /-- Recursively collect .olean files, returning for each its module name together
     with its path relative to `basePath`, slash-separated and with the `.olean`
     suffix stripped (e.g. `"A/B/C"`). The relative path is kept so callers can
@@ -150,8 +176,7 @@ partial def collectOleanFiles (basePath : System.FilePath) (currentPath : System
       let relPath := (path.toString.dropPrefix basePath.toString).toString
       let relPath := (relPath.dropPrefix "/").toString
       let relPath := (relPath.dropSuffix ".olean").toString
-      let moduleName := relPath.replace "/" "."
-      result := result.push (String.toName moduleName, relPath)
+      result := result.push (pathToModuleName relPath, relPath)
   return result
 
 /-- Partition collected olean modules into (source-backed, orphan), where a

--- a/ProbeLean/Version.lean
+++ b/ProbeLean/Version.lean
@@ -1,6 +1,6 @@
 -- Generated from lakefile.toml by tools/gen-version.sh — do not edit manually.
 namespace ProbeLean
 
-def version : String := "0.12.0"
+def version : String := "0.12.1"
 
 end ProbeLean

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -3347,12 +3347,52 @@ def testProjectModuleMembership (result : TestResult) : IO TestResult := do
   result ← test "empty module set matches nothing" (!isProjectModule #[] `Spqr) result
   return result
 
+/-- Module names are derived from olean paths one atomic component per path
+segment, so segments that are not plain identifiers (and would need guillemets
+in source) must survive — `String.toName` collapsed them to `.anonymous`,
+which `importModules` rejects. `moduleNameToRelPath` must invert the
+construction exactly, since source paths rebuilt via `Name.toString` would
+contain guillemets that never appear in file names. -/
+def testPathToModuleName (result : TestResult) : IO TestResult := do
+  let mut result := result
+  IO.println ""
+  IO.println "Testing pathToModuleName..."
+  result ← test "single segment" (pathToModuleName "Analysis" == `Analysis) result
+  result ← test "nested segments" (pathToModuleName "Analysis/Section_1_2" == `Analysis.Section_1_2) result
+  result ← test "guillemet segment"
+    (pathToModuleName "Analysis/Misc/Real-EReal-ENNReal" == `Analysis.Misc.«Real-EReal-ENNReal») result
+  result ← test "guillemet segment is not anonymous"
+    (!(pathToModuleName "Analysis/Misc/Real-EReal-ENNReal").isAnonymous) result
+  result ← test "guillemet module belongs to its library root"
+    (moduleInLibraries (pathToModuleName "Analysis/Misc/Real-EReal-ENNReal") #["Analysis"]) result
+  result ← test "digit-only segment stays a string component, never numeric"
+    (pathToModuleName "A/123" == Lean.Name.mkStr (.mkStr .anonymous "A") "123") result
+  result ← test "segment containing a dot stays one component"
+    (pathToModuleName "A/X.Y" == Lean.Name.mkStr (.mkStr .anonymous "A") "X.Y") result
+  result ← test "segment with a space survives"
+    (pathToModuleName "A/two words" == Lean.Name.mkStr (.mkStr .anonymous "A") "two words") result
+
+  IO.println ""
+  IO.println "Testing moduleNameToRelPath..."
+  result ← test "plain round-trip"
+    (moduleNameToRelPath (pathToModuleName "Analysis/Section_1_2") == some "Analysis/Section_1_2") result
+  result ← test "guillemet round-trip"
+    (moduleNameToRelPath (pathToModuleName "Analysis/Misc/Real-EReal-ENNReal")
+      == some "Analysis/Misc/Real-EReal-ENNReal") result
+  result ← test "digit-only round-trip"
+    (moduleNameToRelPath (pathToModuleName "A/123") == some "A/123") result
+  result ← test "anonymous has no path" (moduleNameToRelPath .anonymous == none) result
+  result ← test "numeric component has no path"
+    (moduleNameToRelPath (Lean.Name.mkNum `A 3) == none) result
+  return result
+
 def main : IO UInt32 := do
   let mut result : TestResult := { passed := 0, failed := 0 }
   result ← testValueOfAndProofDeps result
   result ← testSpecsIgnoreProofDeps result
   result ← testPrimarySpecProofOnlyFallback result
   result ← testProjectModuleMembership result
+  result ← testPathToModuleName result
   result ← testConstants result
   result ← testAnalysisHelpers result
   result ← testPrivateNames result

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "probe-lean"
-version = "0.12.0"
+version = "0.12.1"
 defaultTargets = ["probe-lean"]
 
 [[require]]


### PR DESCRIPTION
Fixes #94.

## What

Two fixes with one root cause — module names and source paths were round-tripped through string parsing/printing that only supports plain-identifier components:

- **`pathToModuleName`** (new): olean relative path → module name, one atomic `Name.mkStr` component per path segment — the same construction Lean core uses in `moduleNameOfFileName`. Previously `String.toName` on the dot-joined path collapsed any non-identifier segment (hyphens, spaces) to `.anonymous`, which `importModules` rejects outright, crashing flagless `extract` on e.g. teorth/analysis (`Analysis.Misc.«Real-EReal-ENNReal»`). Digit-only segments became numeric components instead — a different invalid outcome (Lean's `modToFilePath` rejects `.num`).
- **`moduleNameToRelPath`** (new, exact inverse): module name → relative source path, used by `getModuleSourcePath`. Previously the path came from `Name.toString.replace "." "/"`, whose guillemet quoting (`Misc/«Real-EReal-ENNReal».lean`) never exists on disk, so every declaration in such a module lost `code-path`/`code-text`, source-level attributes, and — because sorry matching needs the location — was conservatively reported `unverified` even when fully proved.

Version bumped to 0.12.1 (bug fixes only).

## Notes

- With `--library`, the pre-fix behavior did not crash but produced silently wrong data: the anonymous name was dropped from the explicit import list (the module survived only if imported transitively), and its declarations were emitted unverified with empty locations, blocking `transitively-verified` for every dependent. On teorth/analysis @ 8f9e0fc (Lean v4.29.0-rc8): 17 atoms unverified with empty `code-path`, 144 dependents held at `verified`. Post-fix, flagless and `--library` produce identical output: 102 modules imported, 3818/3818 verified.
- Consumers keying on `code-module` see guillemet names rendered by `Name.toString` (e.g. `Analysis.Misc.«Real-EReal-ENNReal»`) — unchanged from before for transitively-loaded modules, but such atoms now also appear with correct locations and status.
- 13 new unit tests: component construction (guillemet/digit/dot/space segments), round-trips, `.anonymous`/`.num` rejection.